### PR TITLE
Fixed redirect URI for Google calendar instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ To enable Google Calendar integration:
      - `http://localhost:3000` (for development)
      - Your production URL (if deployed)
    - Set Authorized redirect URIs:
-     - `http://localhost:3000/api/auth/callback/google` (for development)
-     - `https://your-domain.com/api/auth/callback/google` (for production)
+     - `http://localhost:3000/api/calendar/google` (for development)
+     - `https://your-domain.com/api/calendar/google` (for production)
    - Click "Create"
    - Save the generated Client ID and Client Secret
 

--- a/src/components/settings/SystemSettings.tsx
+++ b/src/components/settings/SystemSettings.tsx
@@ -90,7 +90,7 @@ export function SystemSettings() {
                 <li>Create OAuth 2.0 Client ID credentials</li>
                 <li>
                   Add authorized redirect URI: {window.location.origin}
-                  /api/auth/callback/google
+                  /api/calendar/google
                 </li>
                 <li>Copy the Client ID and Client Secret</li>
               </ol>


### PR DESCRIPTION
Fix redirect URI for Google Calendar instructions

Description: This update corrects the redirect URI used for Google Calendar integration. I noticed that the URI specified in the settings and README does not match the one generated by my instance, which prevented a proper connection. I suspect the current URI might be a remnant from an older version.

I'm new to the open source community, so please let me know if I've overlooked anything or if there's a better approach. Thank you for your review!