### PR TITLE
chore: Update Docker image name in workflow configuration

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   REGISTRY: docker.io
-  IMAGE_NAME: eibrahim/fluid-calendar
+  IMAGE_NAME: deadlocks21/fluid-calendar
 
 jobs:
   build:


### PR DESCRIPTION
- Changed IMAGE_NAME from eibrahim/fluid-calendar to deadlocks21/fluid-calendar in docker-publish.yml.