### PR TITLE
Add self-hosting setup review offer

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ By becoming a sponsor, you:
 - Get early access to new features
 - Support open-source software development
 
-## Sponsored By                                                                                     
-                                                                                                  
-<a href="https://www.nitroclaw.com?ref=fluid-calendar">                                             
+## Sponsored By
+
+<a href="https://www.nitroclaw.com?ref=fluid-calendar">
 
    <img width="600" alt="NitroClaw - Your Own OpenClaw Assistant, Zero Server Hassle" src="https://github.com/user-attachments/assets/c258d98c-b06b-4580-82b0-e54281613e54" />
 
@@ -59,6 +59,16 @@ Don't want to self-host? We're currently beta testing our hosted version at [Flu
 - Automatic updates
 - Premium support
 - Advanced AI features
+
+## Paid Self-Hosting Review
+
+Trying to run FluidCalendar yourself and stuck on the database, OAuth callback URLs, Google/Outlook scopes, Docker, or production env values?
+
+Use the [self-hosting setup checklist](docs/self-hosting-setup-checklist.md) first. If you want a second set of eyes, you can buy a focused setup review for **$12**:
+
+[Get a FluidCalendar setup review](https://buy.stripe.com/6oUbJ37ND0OH4ma87I8so06)
+
+The checkout asks for your repo, deploy URL, or setup notes plus the main blocker. The review is a short, manual pass over your public setup details with the next concrete fixes to try. Do not send secrets or private OAuth credentials.
 
 ## Features
 

--- a/docs/self-hosting-setup-checklist.md
+++ b/docs/self-hosting-setup-checklist.md
@@ -1,0 +1,43 @@
+# FluidCalendar Self-Hosting Setup Checklist
+
+Use this checklist before opening an issue or buying a setup review. It focuses on the failure points that most often block a working FluidCalendar install.
+
+## 1. Base App
+
+- `NEXTAUTH_URL` matches the exact URL users open in the browser.
+- `NEXTAUTH_SECRET` is set to a long random value and is the same across restarts.
+- `DATABASE_URL` points to the running Postgres database, not a local placeholder.
+- The app process can run migrations and write to the database.
+- The deployment exposes the same port your reverse proxy routes to.
+
+## 2. Google Calendar
+
+- Google Calendar API and Google People API are enabled in the same Google Cloud project.
+- OAuth consent screen has the correct app name, support email, and developer contact.
+- OAuth redirect URI matches `/api/calendar/google` on the deployed domain.
+- Required scopes are configured, including calendar read/write and user info.
+- Test users are added if the OAuth app is still in testing mode.
+
+## 3. Outlook Calendar
+
+- Azure app registration supports the account type you expect to use.
+- Redirect URI matches `/api/auth/callback/azure-ad` on the deployed domain.
+- Microsoft Graph delegated permissions include calendar, task, profile, and offline access permissions.
+- The client secret value, not the secret ID, is copied into the app config.
+- Tenant ID is set only when you want to restrict login to one tenant.
+
+## 4. Production Readiness
+
+- Public URL uses HTTPS before testing OAuth callbacks.
+- Logs are enabled for app startup, auth callbacks, and calendar sync requests.
+- Backups exist for Postgres before importing real calendar data.
+- Environment values are stored in your host's secret manager, not committed to git.
+- You can restart the app and still log in with the same account.
+
+## Paid Self-Hosting Review
+
+If you want a focused second pass, buy the $12 setup review:
+
+https://buy.stripe.com/6oUbJ37ND0OH4ma87I8so06
+
+The checkout asks for your repo, deploy URL, or setup notes plus the main blocker. Share only public configuration, screenshots, logs, or redacted snippets. Do not send secrets, private OAuth credentials, database passwords, or production tokens.


### PR DESCRIPTION
## Summary
- add a FluidCalendar self-hosting setup checklist for common database, OAuth, and production blockers
- add a $12 setup review Payment Link for users who want a focused second pass
- warn users not to send secrets or private credentials

## Validation
- `git diff --check`
- `npx prettier --check README.md docs/self-hosting-setup-checklist.md`
- pre-commit hook: `npm run lint` and `npm run type-check`
- Stripe payment link verified active/livemode at $12 with setup intake fields
