### PR TITLE
Point setup review at generic Stripe account

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Trying to run FluidCalendar yourself and stuck on the database, OAuth callback U
 
 Use the [self-hosting setup checklist](docs/self-hosting-setup-checklist.md) first. If you want a second set of eyes, you can buy a focused setup review for **$12**:
 
-[Get a FluidCalendar setup review](https://buy.stripe.com/6oUbJ37ND0OH4ma87I8so06)
+[Get a FluidCalendar setup review](https://buy.stripe.com/3cI9AS2799EYgx577zaMU04)
 
 The checkout asks for your repo, deploy URL, or setup notes plus the main blocker. The review is a short, manual pass over your public setup details with the next concrete fixes to try. Do not send secrets or private OAuth credentials.
 

--- a/docs/self-hosting-setup-checklist.md
+++ b/docs/self-hosting-setup-checklist.md
@@ -38,6 +38,6 @@ Use this checklist before opening an issue or buying a setup review. It focuses 
 
 If you want a focused second pass, buy the $12 setup review:
 
-https://buy.stripe.com/6oUbJ37ND0OH4ma87I8so06
+https://buy.stripe.com/3cI9AS2799EYgx577zaMU04
 
 The checkout asks for your repo, deploy URL, or setup notes plus the main blocker. Share only public configuration, screenshots, logs, or redacted snippets. Do not send secrets, private OAuth credentials, database passwords, or production tokens.


### PR DESCRIPTION
## Summary\n- Replace the FluidCalendar setup review checkout URL with the shared generic Stripe account Payment Link.\n\n## Verification\n- git diff --check\n- npx --yes prettier@3.3.3 --config /dev/null --ignore-path /dev/null --check README.md docs/self-hosting-setup-checklist.md\n- Stripe retrieve verified the new link is active/livemode at  with the expected redirect and custom fields.