### PR TITLE
feat(calendar): drag-and-drop to move and resize events and task blocks

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,11 +1,15 @@
 /** @type {import('jest').Config} */
 const config = {
-  preset: "ts-jest",
   testEnvironment: "node",
   moduleNameMapper: {
     "^@/(.*)$": "<rootDir>/src/$1",
   },
   testMatch: ["<rootDir>/src/**/__tests__/**/*.test.ts"],
+  transform: {
+    // isolatedModules keeps jest memory bounded: type-checking is covered by
+    // `tsc --noEmit`, so tests only need transpilation.
+    "^.+\\.tsx?$": ["ts-jest", { isolatedModules: true }],
+  },
 };
 
 module.exports = config;

--- a/src/__tests__/calendar-drag.test.ts
+++ b/src/__tests__/calendar-drag.test.ts
@@ -1,0 +1,207 @@
+import { computeDropUpdate, DragChange } from "@/lib/calendar-drag";
+import { getEventEditability } from "@/lib/calendar-drag";
+import { CalendarEvent, CalendarFeed } from "@/types/calendar";
+
+const googleFeed: CalendarFeed = {
+  id: "feed-1",
+  name: "Personal",
+  type: "GOOGLE",
+  enabled: true,
+};
+
+const feeds = [googleFeed];
+
+function makeEvent(overrides: Partial<CalendarEvent> = {}): CalendarEvent {
+  return {
+    id: "evt-1",
+    feedId: "feed-1",
+    title: "Standup",
+    start: new Date("2026-06-12T15:00:00.000Z"),
+    end: new Date("2026-06-12T15:30:00.000Z"),
+    isRecurring: false,
+    allDay: false,
+    isMaster: false,
+    ...overrides,
+  };
+}
+
+function makeTaskItem(overrides: Partial<CalendarEvent> = {}): CalendarEvent {
+  return makeEvent({
+    id: "task-1",
+    feedId: "tasks",
+    extendedProps: {
+      isTask: true,
+      taskId: "task-1",
+      // getTasksAsEvents adds this beyond the ExtendedEventProps interface
+      isAutoScheduled: true,
+    } as CalendarEvent["extendedProps"],
+    ...overrides,
+  });
+}
+
+function makeChange(
+  item: CalendarEvent,
+  overrides: Partial<DragChange> = {}
+): DragChange {
+  return {
+    item,
+    newStart: new Date("2026-06-12T16:00:00.000Z"),
+    newEnd: new Date("2026-06-12T16:30:00.000Z"),
+    oldStart: new Date("2026-06-12T15:00:00.000Z"),
+    oldEnd: new Date("2026-06-12T15:30:00.000Z"),
+    oldAllDay: false,
+    newAllDay: false,
+    isResize: false,
+    ...overrides,
+  };
+}
+
+describe("computeDropUpdate", () => {
+  it("moves an auto-scheduled task and pins it", () => {
+    const result = computeDropUpdate(makeChange(makeTaskItem()), feeds);
+
+    expect(result.kind).toBe("task");
+    if (result.kind !== "task") return;
+    expect(result.taskId).toBe("task-1");
+    expect(result.updates.scheduledStart).toEqual(
+      new Date("2026-06-12T16:00:00.000Z")
+    );
+    expect(result.updates.scheduledEnd).toEqual(
+      new Date("2026-06-12T16:30:00.000Z")
+    );
+    expect(result.updates.scheduleLocked).toBe(true);
+    expect(result.updates.isAutoScheduled).toBe(true);
+    expect(result.updates.duration).toBeUndefined();
+  });
+
+  it("updates task duration on resize", () => {
+    const result = computeDropUpdate(
+      makeChange(makeTaskItem(), {
+        newEnd: new Date("2026-06-12T17:30:00.000Z"),
+        isResize: true,
+      }),
+      feeds
+    );
+
+    expect(result.kind).toBe("task");
+    if (result.kind !== "task") return;
+    expect(result.updates.duration).toBe(90);
+  });
+
+  it("blocks tasks that are not auto-scheduled", () => {
+    const item = makeTaskItem({
+      extendedProps: {
+        isTask: true,
+        taskId: "task-1",
+        isAutoScheduled: false,
+      } as CalendarEvent["extendedProps"],
+    });
+
+    const result = computeDropUpdate(makeChange(item), feeds);
+    expect(result.kind).toBe("blocked");
+  });
+
+  it("blocks all-day <-> timed transitions", () => {
+    const result = computeDropUpdate(
+      makeChange(makeTaskItem(), { oldAllDay: false, newAllDay: true }),
+      feeds
+    );
+    expect(result.kind).toBe("blocked");
+  });
+
+  it("moves a non-recurring event on a writable feed without a recurrence mode", () => {
+    const result = computeDropUpdate(makeChange(makeEvent()), feeds);
+
+    expect(result.kind).toBe("event");
+    if (result.kind !== "event") return;
+    expect(result.eventId).toBe("evt-1");
+    expect(result.updates.start).toEqual(new Date("2026-06-12T16:00:00.000Z"));
+    expect(result.updates.end).toEqual(new Date("2026-06-12T16:30:00.000Z"));
+    expect(result.updates.allDay).toBe(false);
+    expect("mode" in result).toBe(false);
+  });
+
+  it("moves a recurring instance as a direct patch of its own event id", () => {
+    // The instance row carries its instance-specific external id, so the API
+    // patches exactly this occurrence; mode "single" would re-resolve the
+    // instance by the NEW start time and can hit the wrong occurrence
+    const item = makeEvent({
+      id: "evt-instance",
+      isRecurring: true,
+      isMaster: false,
+      masterEventId: "evt-master",
+    });
+
+    const result = computeDropUpdate(makeChange(item), feeds);
+    expect(result.kind).toBe("event");
+    if (result.kind !== "event") return;
+    expect(result.eventId).toBe("evt-instance");
+    expect("mode" in result).toBe(false);
+  });
+
+  it("blocks events whose feed is missing", () => {
+    const item = makeEvent({ feedId: "feed-gone" });
+    const result = computeDropUpdate(makeChange(item), feeds);
+    expect(result.kind).toBe("blocked");
+  });
+
+  it("preserves the previous duration when FullCalendar reports a null end", () => {
+    const result = computeDropUpdate(
+      makeChange(makeEvent(), { newEnd: null }),
+      feeds
+    );
+
+    expect(result.kind).toBe("event");
+    if (result.kind !== "event") return;
+    // old duration was 30 minutes
+    expect(result.updates.end).toEqual(new Date("2026-06-12T16:30:00.000Z"));
+  });
+});
+
+describe("getEventEditability", () => {
+  it("makes auto-scheduled task blocks fully editable", () => {
+    expect(getEventEditability(makeTaskItem(), feeds)).toEqual({
+      startEditable: true,
+      durationEditable: true,
+    });
+  });
+
+  it("locks non-auto-scheduled task chips", () => {
+    const item = makeTaskItem({
+      allDay: true,
+      extendedProps: {
+        isTask: true,
+        taskId: "task-1",
+        isAutoScheduled: false,
+      } as CalendarEvent["extendedProps"],
+    });
+
+    expect(getEventEditability(item, feeds)).toEqual({
+      startEditable: false,
+      durationEditable: false,
+    });
+  });
+
+  it("makes events on writable feeds editable", () => {
+    expect(getEventEditability(makeEvent(), feeds)).toEqual({
+      startEditable: true,
+      durationEditable: true,
+    });
+  });
+
+  it("locks all-day events", () => {
+    expect(getEventEditability(makeEvent({ allDay: true }), feeds)).toEqual({
+      startEditable: false,
+      durationEditable: false,
+    });
+  });
+
+  it("locks events whose feed is unknown", () => {
+    expect(
+      getEventEditability(makeEvent({ feedId: "feed-gone" }), feeds)
+    ).toEqual({
+      startEditable: false,
+      durationEditable: false,
+    });
+  });
+});

--- a/src/components/calendar/DayView.tsx
+++ b/src/components/calendar/DayView.tsx
@@ -12,6 +12,7 @@ import timeGridPlugin from "@fullcalendar/timegrid";
 
 import { TaskModal } from "@/components/tasks/TaskModal";
 
+import { getEventEditability } from "@/lib/calendar-drag";
 import { useEventModalStore } from "@/lib/commands/groups/calendar";
 import { newDate } from "@/lib/date-utils";
 
@@ -25,6 +26,7 @@ import { Task, TaskStatus } from "@/types/task";
 import { CalendarEventContent } from "./CalendarEventContent";
 import { EventModal } from "./EventModal";
 import { EventQuickView } from "./EventQuickView";
+import { useCalendarDragHandlers } from "./useCalendarDragHandlers";
 
 interface DayViewProps {
   currentDate: Date;
@@ -53,6 +55,8 @@ export function DayView({ currentDate, onDateClick }: DayViewProps) {
       borderColor: string;
       allDay: boolean;
       classNames: string[];
+      startEditable: boolean;
+      durationEditable: boolean;
       extendedProps?: ExtendedEventProps;
     }>
   >([]);
@@ -62,6 +66,7 @@ export function DayView({ currentDate, onDateClick }: DayViewProps) {
   const [isTask, setIsTask] = useState(false);
   const eventModalStore = useEventModalStore();
   const [clickedElement, setClickedElement] = useState<HTMLElement | null>(null);
+  const { handleEventDrop, handleEventResize } = useCalendarDragHandlers();
 
   // Update events when the calendar view changes
   const handleDatesSet = useCallback(
@@ -91,6 +96,7 @@ export function DayView({ currentDate, onDateClick }: DayViewProps) {
           classNames: [
             item.extendedProps?.isTask ? "calendar-task" : "calendar-event",
           ],
+          ...getEventEditability(item, feeds),
           extendedProps: {
             ...item,
             isTask: item.extendedProps?.isTask,
@@ -313,6 +319,11 @@ export function DayView({ currentDate, onDateClick }: DayViewProps) {
         selectMirror={true}
         datesSet={handleDatesSet}
         eventContent={renderEventContent}
+        eventDrop={handleEventDrop}
+        eventResize={handleEventResize}
+        eventResizableFromStart={true}
+        snapDuration="00:15:00"
+        dragRevertDuration={250}
       />
 
       <EventModal

--- a/src/components/calendar/MonthView.tsx
+++ b/src/components/calendar/MonthView.tsx
@@ -12,6 +12,7 @@ import FullCalendar from "@fullcalendar/react";
 
 import { TaskModal } from "@/components/tasks/TaskModal";
 
+import { getEventEditability } from "@/lib/calendar-drag";
 import { useEventModalStore } from "@/lib/commands/groups/calendar";
 import { newDate } from "@/lib/date-utils";
 
@@ -25,6 +26,7 @@ import { Task, TaskStatus } from "@/types/task";
 import { CalendarEventContent } from "./CalendarEventContent";
 import { EventModal } from "./EventModal";
 import { EventQuickView } from "./EventQuickView";
+import { useCalendarDragHandlers } from "./useCalendarDragHandlers";
 
 interface MonthViewProps {
   currentDate: Date;
@@ -53,6 +55,8 @@ export function MonthView({ currentDate, onDateClick }: MonthViewProps) {
       borderColor: string;
       allDay: boolean;
       classNames: string[];
+      startEditable: boolean;
+      durationEditable: boolean;
       extendedProps?: ExtendedEventProps;
     }>
   >([]);
@@ -62,6 +66,7 @@ export function MonthView({ currentDate, onDateClick }: MonthViewProps) {
   const [isTask, setIsTask] = useState(false);
   const eventModalStore = useEventModalStore();
   const [clickedElement, setClickedElement] = useState<HTMLElement | null>(null);
+  const { handleEventDrop } = useCalendarDragHandlers();
 
   // Update events when the calendar view changes
   const handleDatesSet = useCallback(
@@ -91,6 +96,9 @@ export function MonthView({ currentDate, onDateClick }: MonthViewProps) {
           classNames: [
             item.extendedProps?.isTask ? "calendar-task" : "calendar-event",
           ],
+          ...getEventEditability(item, feeds),
+          // Resizing needs a time grid; month view only supports moving
+          durationEditable: false,
           extendedProps: {
             ...item,
             isTask: item.extendedProps?.isTask,
@@ -274,6 +282,8 @@ export function MonthView({ currentDate, onDateClick }: MonthViewProps) {
         selectMirror={true}
         datesSet={handleDatesSet}
         eventContent={renderEventContent}
+        eventDrop={handleEventDrop}
+        dragRevertDuration={250}
       />
 
       <EventModal

--- a/src/components/calendar/WeekView.tsx
+++ b/src/components/calendar/WeekView.tsx
@@ -12,6 +12,7 @@ import timeGridPlugin from "@fullcalendar/timegrid";
 
 import { TaskModal } from "@/components/tasks/TaskModal";
 
+import { getEventEditability } from "@/lib/calendar-drag";
 import { useEventModalStore } from "@/lib/commands/groups/calendar";
 import { newDate } from "@/lib/date-utils";
 
@@ -25,6 +26,7 @@ import { Task, TaskStatus } from "@/types/task";
 import { CalendarEventContent } from "./CalendarEventContent";
 import { EventModal } from "./EventModal";
 import { EventQuickView } from "./EventQuickView";
+import { useCalendarDragHandlers } from "./useCalendarDragHandlers";
 
 interface WeekViewProps {
   currentDate: Date;
@@ -53,6 +55,8 @@ export function WeekView({ currentDate, onDateClick }: WeekViewProps) {
       borderColor: string;
       allDay: boolean;
       classNames: string[];
+      startEditable: boolean;
+      durationEditable: boolean;
       extendedProps?: ExtendedEventProps;
     }>
   >([]);
@@ -62,6 +66,7 @@ export function WeekView({ currentDate, onDateClick }: WeekViewProps) {
   const [isTask, setIsTask] = useState(false);
   const eventModalStore = useEventModalStore();
   const [clickedElement, setClickedElement] = useState<HTMLElement | null>(null);
+  const { handleEventDrop, handleEventResize } = useCalendarDragHandlers();
 
   // Update events when the calendar view changes
   const handleDatesSet = useCallback(
@@ -92,6 +97,7 @@ export function WeekView({ currentDate, onDateClick }: WeekViewProps) {
           classNames: [
             item.extendedProps?.isTask ? "calendar-task" : "calendar-event",
           ],
+          ...getEventEditability(item, feeds),
           // Store the original event data
           extendedProps: {
             ...item,
@@ -320,6 +326,11 @@ export function WeekView({ currentDate, onDateClick }: WeekViewProps) {
         selectMirror={true}
         datesSet={handleDatesSet}
         eventContent={renderEventContent}
+        eventDrop={handleEventDrop}
+        eventResize={handleEventResize}
+        eventResizableFromStart={true}
+        snapDuration="00:15:00"
+        dragRevertDuration={250}
       />
       {quickViewItem && (
         <EventQuickView

--- a/src/components/calendar/useCalendarDragHandlers.ts
+++ b/src/components/calendar/useCalendarDragHandlers.ts
@@ -1,0 +1,84 @@
+import { useCallback } from "react";
+
+import type { EventDropArg } from "@fullcalendar/core";
+import type { EventResizeDoneArg } from "@fullcalendar/interaction";
+import { toast } from "sonner";
+
+import { computeDropUpdate } from "@/lib/calendar-drag";
+
+import { useCalendarStore } from "@/store/calendar";
+import { useTaskStore } from "@/store/task";
+
+import { CalendarEvent } from "@/types/calendar";
+
+// Shared eventDrop/eventResize handlers for the calendar views. The views
+// spread the original store item into extendedProps, so it is recovered here.
+export function useCalendarDragHandlers() {
+  const feeds = useCalendarStore((s) => s.feeds);
+  const updateEvent = useCalendarStore((s) => s.updateEvent);
+  const updateTask = useTaskStore((s) => s.updateTask);
+
+  const applyChange = useCallback(
+    async (info: EventDropArg | EventResizeDoneArg, isResize: boolean) => {
+      const item = info.event.extendedProps as CalendarEvent;
+      if (!info.event.start) {
+        info.revert();
+        return;
+      }
+
+      const update = computeDropUpdate(
+        {
+          item,
+          newStart: info.event.start,
+          newEnd: info.event.end,
+          oldStart: info.oldEvent.start,
+          oldEnd: info.oldEvent.end,
+          oldAllDay: info.oldEvent.allDay,
+          newAllDay: info.event.allDay,
+          isResize,
+        },
+        feeds
+      );
+
+      if (update.kind === "blocked") {
+        info.revert();
+        toast.error(update.reason);
+        return;
+      }
+
+      try {
+        if (update.kind === "task") {
+          await updateTask(update.taskId, update.updates);
+        } else {
+          // No mode: the API routes resolve this row's own external event id
+          // (a recurring instance carries its instance-specific id), so a
+          // direct patch updates exactly this occurrence. mode "single" would
+          // instead look the instance up by the NEW start time and can patch
+          // the wrong occurrence.
+          await updateEvent(update.eventId, update.updates);
+        }
+      } catch (error) {
+        console.error("Failed to apply calendar drag change:", error);
+        info.revert();
+        toast.error(isResize ? "Failed to resize item" : "Failed to move item");
+      }
+    },
+    [feeds, updateEvent, updateTask]
+  );
+
+  const handleEventDrop = useCallback(
+    (info: EventDropArg) => {
+      void applyChange(info, false);
+    },
+    [applyChange]
+  );
+
+  const handleEventResize = useCallback(
+    (info: EventResizeDoneArg) => {
+      void applyChange(info, true);
+    },
+    [applyChange]
+  );
+
+  return { handleEventDrop, handleEventResize };
+}

--- a/src/lib/calendar-drag.ts
+++ b/src/lib/calendar-drag.ts
@@ -1,0 +1,114 @@
+import { CalendarEvent, CalendarFeed } from "@/types/calendar";
+import { UpdateTask } from "@/types/task";
+
+// Extra fields getTasksAsEvents puts on extendedProps beyond ExtendedEventProps
+interface TaskDragProps {
+  isTask?: boolean;
+  taskId?: string;
+  isAutoScheduled?: boolean;
+}
+
+const WRITABLE_FEED_TYPES = new Set(["GOOGLE", "OUTLOOK", "CALDAV"]);
+
+export interface DragChange {
+  item: CalendarEvent;
+  newStart: Date;
+  newEnd: Date | null;
+  oldStart: Date | null;
+  oldEnd: Date | null;
+  oldAllDay: boolean;
+  newAllDay: boolean;
+  isResize: boolean;
+}
+
+export type DropUpdate =
+  | { kind: "task"; taskId: string; updates: UpdateTask }
+  | {
+      kind: "event";
+      eventId: string;
+      updates: { start: Date; end: Date; allDay: boolean };
+    }
+  | { kind: "blocked"; reason: string };
+
+export function getEventEditability(
+  item: CalendarEvent,
+  feeds: CalendarFeed[]
+): { startEditable: boolean; durationEditable: boolean } {
+  const props = item.extendedProps as TaskDragProps | undefined;
+
+  if (props?.isTask) {
+    // Non-auto-scheduled tasks render as all-day due-date chips; moving one
+    // would mean changing its due date, which drag doesn't support yet
+    const editable =
+      Boolean(props.isAutoScheduled) && Boolean(props.taskId) && !item.allDay;
+    return { startEditable: editable, durationEditable: editable };
+  }
+
+  if (item.allDay) {
+    // All-day events use date (not dateTime) in external APIs; dragging them
+    // risks converting them to timed events
+    return { startEditable: false, durationEditable: false };
+  }
+
+  const feed = feeds.find((f) => f.id === item.feedId);
+  const editable = Boolean(feed && WRITABLE_FEED_TYPES.has(feed.type));
+  return { startEditable: editable, durationEditable: editable };
+}
+
+export function computeDropUpdate(
+  change: DragChange,
+  feeds: CalendarFeed[]
+): DropUpdate {
+  const { item, newStart, oldStart, oldEnd, oldAllDay, newAllDay, isResize } =
+    change;
+
+  if (oldAllDay !== newAllDay) {
+    return {
+      kind: "blocked",
+      reason:
+        "Switching between all-day and timed isn't supported — edit the item instead",
+    };
+  }
+
+  // FullCalendar reports end as null for zero-duration events; preserve the
+  // previous duration in that case
+  const oldDurationMs =
+    oldStart && oldEnd ? oldEnd.getTime() - oldStart.getTime() : 0;
+  const newEnd =
+    change.newEnd ?? new Date(newStart.getTime() + oldDurationMs);
+
+  const props = item.extendedProps as TaskDragProps | undefined;
+  if (props?.isTask) {
+    if (!props.taskId || !props.isAutoScheduled) {
+      return {
+        kind: "blocked",
+        reason: "Only auto-scheduled tasks can be moved on the calendar",
+      };
+    }
+    const updates: UpdateTask = {
+      scheduledStart: newStart,
+      scheduledEnd: newEnd,
+      // A manual move pins the task; otherwise the next auto-schedule run
+      // (triggered by this very update) would immediately move it back
+      scheduleLocked: true,
+      isAutoScheduled: true,
+    };
+    if (isResize) {
+      updates.duration = Math.round(
+        (newEnd.getTime() - newStart.getTime()) / 60000
+      );
+    }
+    return { kind: "task", taskId: props.taskId, updates };
+  }
+
+  const feed = feeds.find((f) => f.id === item.feedId);
+  if (!feed || !WRITABLE_FEED_TYPES.has(feed.type)) {
+    return { kind: "blocked", reason: "This calendar is read-only" };
+  }
+
+  return {
+    kind: "event",
+    eventId: item.id,
+    updates: { start: newStart, end: newEnd, allDay: item.allDay },
+  };
+}

--- a/src/services/scheduling/SlotScorer.ts
+++ b/src/services/scheduling/SlotScorer.ts
@@ -25,13 +25,16 @@ export class SlotScorer {
   updateScheduledTasks(tasks: Task[]) {
     this.scheduledTasks.clear();
     tasks.forEach((task) => {
-      if (task.projectId && task.scheduledStart && task.scheduledEnd) {
-        const projectTasks = this.scheduledTasks.get(task.projectId) || [];
+      if (task.scheduledStart && task.scheduledEnd) {
+        // Tasks without a project share the "none" bucket that
+        // addScheduledTaskConflict uses, so hasInMemoryConflict sees them
+        const key = task.projectId || "none";
+        const projectTasks = this.scheduledTasks.get(key) || [];
         projectTasks.push({
           start: task.scheduledStart,
           end: task.scheduledEnd,
         });
-        this.scheduledTasks.set(task.projectId, projectTasks);
+        this.scheduledTasks.set(key, projectTasks);
       }
     });
   }

--- a/src/services/scheduling/TimeSlotManager.ts
+++ b/src/services/scheduling/TimeSlotManager.ts
@@ -66,7 +66,10 @@ export class TimeSlotManagerImpl implements TimeSlotManager {
         isAutoScheduled: true,
         scheduledStart: { not: null },
         scheduledEnd: { not: null },
-        projectId: { not: null },
+        // Locked tasks keep their slots across runs, so they must count as
+        // busy no matter what project they belong to (or none at all);
+        // unlocked tasks are about to be rescheduled and must not block
+        scheduleLocked: true,
         userId,
       },
     });


### PR DESCRIPTION
## Summary

Adds drag-and-drop editing to the calendar — the most-requested missing interaction (#136, also overlaps with the use cases in #79). FullCalendar's `interaction` plugin was already bundled; this wires up `eventDrop`/`eventResize` with per-item editability rules and routes drops through the existing mutation paths.

Closes #136

## What you can do now

- **Week/Day views:** drag to move, resize from either edge (15-min snap)
- **Month view:** drag to another day, preserving time-of-day (no resize — needs a time grid)
- **Auto-scheduled task blocks:** dragging sets `scheduleLocked` (a manual move pins the task — otherwise the auto-schedule run triggered by the very same update would immediately move it back; the existing lock UI is the unpin affordance). Resizing also updates `duration`.
- **Recurring events:** dragging an occurrence moves only that occurrence

## Editability rules

| Item | Move | Resize |
|---|---|---|
| Auto-scheduled task block | ✓ (pins) | ✓ (updates duration) |
| Event on GOOGLE/OUTLOOK/CALDAV feed | ✓ | ✓ |
| Recurring event instance | ✓ (that occurrence only) | ✓ |
| All-day events / due-date task chips | ✗ | ✗ |
| All-day ↔ timed conversion | blocked (revert + toast) | — |

All-day items stay locked because external APIs use `date` vs `dateTime` and a careless drag would convert the event type. Failed/blocked drops call `info.revert()` and show a toast.

## Design note: recurring instances are patched directly, without `mode: "single"`

The existing `mode: "single"` path in `updateGoogleEvent` re-resolves the instance via `events.instances({ timeMin: <new start>, maxResults: 1 })`. Because `timeMin` is the *new* start time, dragging an occurrence across its neighbors can resolve — and patch — the wrong occurrence. Since the calendar only ever renders real instance rows (each carrying its own instance-specific external id), drops omit `mode` so the API patches exactly the dragged occurrence.

## Included fix: pinned tasks outside a project could be double-booked

`TimeSlotManager.updateScheduledTasks` seeded the scheduler's busy map with `projectId: { not: null }`, so a locked task without a project was invisible to subsequent scheduling runs and other tasks could be placed on top of it. The seed now loads locked tasks regardless of project (unlocked ones are about to be rescheduled and shouldn't block), bucketed under the same `"none"` key `addScheduledTaskConflict` already uses. This pre-existed, but drag-pinning made it easy to hit.

## Implementation

- `src/lib/calendar-drag.ts` — pure `computeDropUpdate` / `getEventEditability` (no store/DOM access), unit-tested
- `src/components/calendar/useCalendarDragHandlers.ts` — shared hook consumed by Week/Day/Month views
- 13 unit tests in `src/__tests__/calendar-drag.test.ts`
- jest now runs ts-jest with `isolatedModules` (transpile-only keeps memory bounded; `tsc --noEmit` covers types)

## Testing

- `npx jest calendar-drag` — 13/13 pass; `tsc --noEmit` and `next lint` clean
- Live-tested against Google Calendar: move/resize of events, recurring occurrences, and task blocks all verified to propagate (including delete-cleanup), plus revert-on-blocked cases