### PR TITLE
fix(calendar): show time and calendar color for timed events in month view (#95)

### DIFF
--- a/src/__tests__/calendar-event-display.test.ts
+++ b/src/__tests__/calendar-event-display.test.ts
@@ -1,0 +1,131 @@
+import {
+  formatEventTime,
+  getMonthEventDisplay,
+  isDayGridView,
+} from "@/lib/calendar-event-display";
+
+// Dates are built with the local-time constructor (year, monthIndex, day, hour,
+// minute) so the formatted output is independent of the machine's time zone.
+
+describe("formatEventTime", () => {
+  it("formats an afternoon time in 12-hour mode", () => {
+    expect(formatEventTime(new Date(2026, 5, 12, 15, 30), "12h")).toBe(
+      "3:30 PM"
+    );
+  });
+
+  it("formats an afternoon time in 24-hour mode", () => {
+    expect(formatEventTime(new Date(2026, 5, 12, 15, 30), "24h")).toBe("15:30");
+  });
+
+  it("formats midnight in 12-hour mode as 12:00 AM", () => {
+    expect(formatEventTime(new Date(2026, 5, 12, 0, 0), "12h")).toBe(
+      "12:00 AM"
+    );
+  });
+
+  it("formats noon in 12-hour mode as 12:00 PM", () => {
+    expect(formatEventTime(new Date(2026, 5, 12, 12, 0), "12h")).toBe(
+      "12:00 PM"
+    );
+  });
+
+  it("zero-pads hours and minutes in 24-hour mode", () => {
+    expect(formatEventTime(new Date(2026, 5, 12, 9, 5), "24h")).toBe("09:05");
+  });
+
+  it("zero-pads minutes in 12-hour mode", () => {
+    expect(formatEventTime(new Date(2026, 5, 12, 9, 5), "12h")).toBe("9:05 AM");
+  });
+});
+
+describe("isDayGridView", () => {
+  it("treats the month view as a day-grid view", () => {
+    expect(isDayGridView("dayGridMonth")).toBe(true);
+  });
+
+  it("treats the multi-month view as a day-grid view", () => {
+    expect(isDayGridView("multiMonthYear")).toBe(true);
+  });
+
+  it("does not treat the time-grid week view as a day-grid view", () => {
+    expect(isDayGridView("timeGridWeek")).toBe(false);
+  });
+
+  it("does not treat the time-grid day view as a day-grid view", () => {
+    expect(isDayGridView("timeGridDay")).toBe(false);
+  });
+});
+
+describe("getMonthEventDisplay", () => {
+  const base = {
+    viewType: "dayGridMonth",
+    allDay: false,
+    isTask: false,
+    start: new Date(2026, 5, 12, 15, 30),
+    isStart: true,
+    timeFormat: "12h" as const,
+  };
+
+  it("shows a colored time chip for a single-day timed event in month view", () => {
+    const display = getMonthEventDisplay(base);
+    expect(display.isDayGridTimed).toBe(true);
+    expect(display.showTimeChip).toBe(true);
+    expect(display.timeText).toBe("3:30 PM");
+  });
+
+  it("keeps the calendar identity but drops the time on a continuation segment", () => {
+    // FullCalendar splits a multi-day event into one segment per day. Only the
+    // first segment is the start, so later segments must not repeat the start
+    // time, but they remain colored and so still need the accessible calendar
+    // label exposed (isDayGridTimed stays true).
+    const display = getMonthEventDisplay({ ...base, isStart: false });
+    expect(display.isDayGridTimed).toBe(true);
+    expect(display.showTimeChip).toBe(false);
+    expect(display.timeText).toBe("");
+  });
+
+  it("is not a day-grid timed event for an all-day event", () => {
+    const display = getMonthEventDisplay({ ...base, allDay: true });
+    expect(display.isDayGridTimed).toBe(false);
+    expect(display.showTimeChip).toBe(false);
+    expect(display.timeText).toBe("");
+  });
+
+  it("is not a day-grid timed event for a task", () => {
+    const display = getMonthEventDisplay({ ...base, isTask: true });
+    expect(display.isDayGridTimed).toBe(false);
+    expect(display.showTimeChip).toBe(false);
+    expect(display.timeText).toBe("");
+  });
+
+  it("is not a day-grid timed event in the time-grid week view", () => {
+    const display = getMonthEventDisplay({ ...base, viewType: "timeGridWeek" });
+    expect(display.isDayGridTimed).toBe(false);
+    expect(display.showTimeChip).toBe(false);
+    expect(display.timeText).toBe("");
+  });
+
+  it("shows a time chip in the multi-month view", () => {
+    const display = getMonthEventDisplay({
+      ...base,
+      viewType: "multiMonthYear",
+    });
+    expect(display.isDayGridTimed).toBe(true);
+    expect(display.showTimeChip).toBe(true);
+    expect(display.timeText).toBe("3:30 PM");
+  });
+
+  it("respects the 24-hour time format setting", () => {
+    const display = getMonthEventDisplay({ ...base, timeFormat: "24h" });
+    expect(display.showTimeChip).toBe(true);
+    expect(display.timeText).toBe("15:30");
+  });
+
+  it("does not show a time chip when the start time is missing", () => {
+    const display = getMonthEventDisplay({ ...base, start: null });
+    expect(display.isDayGridTimed).toBe(false);
+    expect(display.showTimeChip).toBe(false);
+    expect(display.timeText).toBe("");
+  });
+});

--- a/src/__tests__/calendar-event-display.test.ts
+++ b/src/__tests__/calendar-event-display.test.ts
@@ -37,6 +37,43 @@ describe("formatEventTime", () => {
   it("zero-pads minutes in 12-hour mode", () => {
     expect(formatEventTime(new Date(2026, 5, 12, 9, 5), "12h")).toBe("9:05 AM");
   });
+
+  it("defaults to local time when no time zone is given", () => {
+    // Built with the local-time constructor, so the local-zone result is
+    // deterministic regardless of the machine's time zone.
+    expect(formatEventTime(new Date(2026, 5, 12, 15, 30), "12h")).toBe(
+      "3:30 PM"
+    );
+  });
+
+  it("treats an explicit \"local\" time zone the same as the default", () => {
+    expect(formatEventTime(new Date(2026, 5, 12, 15, 30), "12h", "local")).toBe(
+      "3:30 PM"
+    );
+  });
+});
+
+describe("formatEventTime with a configured time zone", () => {
+  // A single absolute instant (built from UTC) renders as different wall-clock
+  // times in different zones. Passing an explicit IANA zone makes the expected
+  // output independent of the machine's local zone - this is the case where the
+  // browser's local zone differs from the calendar's configured zone.
+  const instant = new Date(Date.UTC(2026, 5, 12, 23, 30)); // 23:30Z, June (DST)
+
+  it("formats the instant in America/New_York (UTC-4 in June)", () => {
+    expect(formatEventTime(instant, "12h", "America/New_York")).toBe("7:30 PM");
+    expect(formatEventTime(instant, "24h", "America/New_York")).toBe("19:30");
+  });
+
+  it("formats the same instant in Asia/Tokyo (UTC+9, next day)", () => {
+    expect(formatEventTime(instant, "12h", "Asia/Tokyo")).toBe("8:30 AM");
+    expect(formatEventTime(instant, "24h", "Asia/Tokyo")).toBe("08:30");
+  });
+
+  it("formats the same instant in UTC", () => {
+    expect(formatEventTime(instant, "12h", "UTC")).toBe("11:30 PM");
+    expect(formatEventTime(instant, "24h", "UTC")).toBe("23:30");
+  });
 });
 
 describe("isDayGridView", () => {
@@ -127,5 +164,18 @@ describe("getMonthEventDisplay", () => {
     expect(display.isDayGridTimed).toBe(false);
     expect(display.showTimeChip).toBe(false);
     expect(display.timeText).toBe("");
+  });
+
+  it("formats the time chip in the calendar's configured time zone", () => {
+    // The chip must show whatever time the calendar itself renders, so it
+    // formats in the time zone FullCalendar is configured with rather than the
+    // browser's local zone.
+    const display = getMonthEventDisplay({
+      ...base,
+      start: new Date(Date.UTC(2026, 5, 12, 23, 30)),
+      timeZone: "America/New_York",
+    });
+    expect(display.showTimeChip).toBe(true);
+    expect(display.timeText).toBe("7:30 PM");
   });
 });

--- a/src/components/calendar/CalendarEventContent.tsx
+++ b/src/components/calendar/CalendarEventContent.tsx
@@ -3,10 +3,15 @@ import { memo } from "react";
 import type { EventContentArg } from "@fullcalendar/core";
 import { IoCheckmarkCircle, IoRepeat, IoTimeOutline } from "react-icons/io5";
 
+import { getMonthEventDisplay } from "@/lib/calendar-event-display";
 import { isTaskOverdue } from "@/lib/task-utils";
 import { cn } from "@/lib/utils";
 
+import { useSettingsStore } from "@/store/settings";
+
 import { Priority, TaskStatus } from "@/types/task";
+
+const DEFAULT_EVENT_COLOR = "#3b82f6";
 
 interface CalendarEventContentProps {
   eventInfo: EventContentArg;
@@ -22,11 +27,13 @@ const priorityColors = {
 export const CalendarEventContent = memo(function CalendarEventContent({
   eventInfo,
 }: CalendarEventContentProps) {
+  const { user: userSettings } = useSettingsStore();
   const isTask = eventInfo.event.extendedProps.isTask;
   const isRecurring = eventInfo.event.extendedProps.isRecurring;
   const status = eventInfo.event.extendedProps.status;
   const priority = eventInfo.event.extendedProps.priority;
   const location = eventInfo.event.extendedProps.location;
+  const calendarName = eventInfo.event.extendedProps.calendarName;
   const dueDate = eventInfo.event.extendedProps?.extendedProps?.dueDate;
   const title = eventInfo.event.title;
   const endTime = eventInfo.event.end?.getTime() ?? 0;
@@ -34,6 +41,22 @@ export const CalendarEventContent = memo(function CalendarEventContent({
   const duration = endTime - startTime;
 
   const isOverdue = isTask && isTaskOverdue({ dueDate, status });
+
+  // Issue #95: surface the start time and calendar color for timed events in
+  // month/multi-month views so they read as clearly as the colored all-day
+  // events. Time-grid (day/week) views are unaffected.
+  const { isDayGridTimed, showTimeChip, timeText } = getMonthEventDisplay({
+    viewType: eventInfo.view.type,
+    allDay: eventInfo.event.allDay,
+    isTask: !!isTask,
+    start: eventInfo.event.start,
+    isStart: eventInfo.isStart,
+    timeFormat: userSettings.timeFormat,
+  });
+  const eventColor =
+    eventInfo.event.backgroundColor ||
+    eventInfo.event.borderColor ||
+    DEFAULT_EVENT_COLOR;
 
   return (
     <div
@@ -56,6 +79,19 @@ export const CalendarEventContent = memo(function CalendarEventContent({
       <div className="flex w-full items-center gap-1.5">
         {isTask ? (
           <IoCheckmarkCircle className="h-3.5 w-3.5 flex-shrink-0 text-current opacity-75" />
+        ) : showTimeChip ? (
+          isRecurring ? (
+            <IoRepeat
+              className="h-3.5 w-3.5 flex-shrink-0"
+              style={{ color: eventColor }}
+            />
+          ) : (
+            <span
+              aria-hidden="true"
+              className="h-2 w-2 flex-shrink-0 rounded-full"
+              style={{ backgroundColor: eventColor }}
+            />
+          )
         ) : isRecurring ? (
           <IoRepeat className="h-3.5 w-3.5 flex-shrink-0 text-current opacity-75" />
         ) : (
@@ -68,6 +104,14 @@ export const CalendarEventContent = memo(function CalendarEventContent({
               duration <= 1800000 ? "truncate" : "line-clamp-2 break-words"
             )}
           >
+            {isDayGridTimed && calendarName && (
+              <span className="sr-only">{calendarName}, </span>
+            )}
+            {showTimeChip && timeText && (
+              <span className="mr-1 font-normal tabular-nums opacity-75">
+                {timeText}
+              </span>
+            )}
             {title}
           </div>
         </div>

--- a/src/components/calendar/CalendarEventContent.tsx
+++ b/src/components/calendar/CalendarEventContent.tsx
@@ -45,6 +45,12 @@ export const CalendarEventContent = memo(function CalendarEventContent({
   // Issue #95: surface the start time and calendar color for timed events in
   // month/multi-month views so they read as clearly as the colored all-day
   // events. Time-grid (day/week) views are unaffected.
+  // Format the chip in the same time zone FullCalendar renders with (its
+  // `local` sentinel today) so the chip time always matches the calendar's own
+  // display, even if the browser's local zone differs from the configured one.
+  const calendarTimeZone =
+    (eventInfo.view.calendar.getOption("timeZone") as string | undefined) ??
+    "local";
   const { isDayGridTimed, showTimeChip, timeText } = getMonthEventDisplay({
     viewType: eventInfo.view.type,
     allDay: eventInfo.event.allDay,
@@ -52,6 +58,7 @@ export const CalendarEventContent = memo(function CalendarEventContent({
     start: eventInfo.event.start,
     isStart: eventInfo.isStart,
     timeFormat: userSettings.timeFormat,
+    timeZone: calendarTimeZone,
   });
   const eventColor =
     eventInfo.event.backgroundColor ||

--- a/src/components/calendar/MonthView.tsx
+++ b/src/components/calendar/MonthView.tsx
@@ -105,6 +105,9 @@ export function MonthView({ currentDate, onDateClick }: MonthViewProps) {
             isRecurring: item.isRecurring,
             status: item.extendedProps?.status,
             priority: item.extendedProps?.priority,
+            // Used as the accessible label for the timed-event color dot so
+            // calendar identity is not conveyed by color alone (issue #95).
+            calendarName: feeds.find((f) => f.id === item.feedId)?.name,
           },
         }));
 

--- a/src/components/calendar/MultiMonthView.tsx
+++ b/src/components/calendar/MultiMonthView.tsx
@@ -100,6 +100,9 @@ export function MultiMonthView({
             isRecurring: item.isRecurring,
             status: item.extendedProps?.status,
             priority: item.extendedProps?.priority,
+            // Used as the accessible label for the timed-event color dot so
+            // calendar identity is not conveyed by color alone (issue #95).
+            calendarName: feeds.find((f) => f.id === item.feedId)?.name,
           },
         }));
 

--- a/src/lib/calendar-event-display.ts
+++ b/src/lib/calendar-event-display.ts
@@ -1,4 +1,13 @@
+import { toZonedTime } from "date-fns-tz";
+
 import { TimeFormat } from "@/types/settings";
+
+/**
+ * FullCalendar's sentinel for "render in the browser's local time zone". When
+ * the calendar is configured with this (its current setting), the browser zone
+ * already governs the displayed time, so no conversion is needed.
+ */
+const LOCAL_TIME_ZONE = "local";
 
 /**
  * Day-grid views (month, multi-month) render events as compact chips inside a
@@ -14,10 +23,22 @@ export function isDayGridView(viewType: string): boolean {
  * Format an event's start time for compact display in a month cell, honoring
  * the user's 12h/24h preference. Implemented locally (rather than via date-fns
  * locale formatting) so the output is deterministic regardless of locale.
+ *
+ * `timeZone` is the zone FullCalendar is configured to render with (its `local`
+ * sentinel by default). The chip is derived from the same `event.start` instant
+ * FullCalendar uses, so formatting in that same zone keeps the chip's time in
+ * lockstep with what the calendar actually renders, even if the browser's local
+ * zone differs from the configured one.
  */
-export function formatEventTime(date: Date, timeFormat: TimeFormat): string {
-  const hours = date.getHours();
-  const minutes = date.getMinutes();
+export function formatEventTime(
+  date: Date,
+  timeFormat: TimeFormat,
+  timeZone: string = LOCAL_TIME_ZONE
+): string {
+  const zoned =
+    timeZone === LOCAL_TIME_ZONE ? date : toZonedTime(date, timeZone);
+  const hours = zoned.getHours();
+  const minutes = zoned.getMinutes();
   const mm = minutes.toString().padStart(2, "0");
 
   if (timeFormat === "24h") {
@@ -68,8 +89,21 @@ export function getMonthEventDisplay(params: {
   start: Date | null;
   isStart: boolean;
   timeFormat: TimeFormat;
+  /**
+   * The time zone FullCalendar is configured to render with. Defaults to its
+   * `local` sentinel so the chip tracks the calendar's own rendering.
+   */
+  timeZone?: string;
 }): MonthEventDisplay {
-  const { viewType, allDay, isTask, start, isStart, timeFormat } = params;
+  const {
+    viewType,
+    allDay,
+    isTask,
+    start,
+    isStart,
+    timeFormat,
+    timeZone = LOCAL_TIME_ZONE,
+  } = params;
 
   const isDayGridTimed =
     isDayGridView(viewType) && !allDay && !isTask && start !== null;
@@ -80,6 +114,9 @@ export function getMonthEventDisplay(params: {
   return {
     isDayGridTimed,
     showTimeChip,
-    timeText: showTimeChip && start ? formatEventTime(start, timeFormat) : "",
+    timeText:
+      showTimeChip && start
+        ? formatEventTime(start, timeFormat, timeZone)
+        : "",
   };
 }

--- a/src/lib/calendar-event-display.ts
+++ b/src/lib/calendar-event-display.ts
@@ -1,0 +1,85 @@
+import { TimeFormat } from "@/types/settings";
+
+/**
+ * Day-grid views (month, multi-month) render events as compact chips inside a
+ * day cell. Time-grid views (day, week) already lay events out on a time axis
+ * and color the event block, so the month-style "time + colored dot" treatment
+ * only applies to day-grid views.
+ */
+export function isDayGridView(viewType: string): boolean {
+  return viewType.startsWith("dayGrid") || viewType.startsWith("multiMonth");
+}
+
+/**
+ * Format an event's start time for compact display in a month cell, honoring
+ * the user's 12h/24h preference. Implemented locally (rather than via date-fns
+ * locale formatting) so the output is deterministic regardless of locale.
+ */
+export function formatEventTime(date: Date, timeFormat: TimeFormat): string {
+  const hours = date.getHours();
+  const minutes = date.getMinutes();
+  const mm = minutes.toString().padStart(2, "0");
+
+  if (timeFormat === "24h") {
+    return `${hours.toString().padStart(2, "0")}:${mm}`;
+  }
+
+  const period = hours >= 12 ? "PM" : "AM";
+  const h12 = hours % 12 === 0 ? 12 : hours % 12;
+  return `${h12}:${mm} ${period}`;
+}
+
+export interface MonthEventDisplay {
+  /**
+   * Whether this is a timed (non-all-day, non-task) event rendered in a
+   * day-grid view, for any segment. Day-grid views color every segment of an
+   * event, so this drives the accessible calendar-name label that keeps that
+   * color cue from being the only way to identify the calendar.
+   */
+  isDayGridTimed: boolean;
+  /**
+   * Whether to render the month-style timed chip: a calendar-colored dot
+   * followed by the event's start time. True only on the starting segment, so
+   * multi-day continuation segments don't repeat the start time.
+   */
+  showTimeChip: boolean;
+  /** The formatted start time, or "" when there is no time chip to show. */
+  timeText: string;
+}
+
+/**
+ * Decide how a timed event should be presented in a day-grid (month) cell.
+ *
+ * Issue #95: timed events in month view previously showed only a generic clock
+ * icon, with no time and no calendar color, making them hard to scan next to
+ * the colored all-day events. Timed, non-task events in day-grid views now get
+ * a calendar-colored dot plus their start time. All-day events, tasks, and
+ * time-grid views keep their existing treatment.
+ *
+ * `isStart` is FullCalendar's per-segment flag: a multi-day event is rendered
+ * as one segment per day, and only the first segment carries the real start
+ * time. Later segments must not repeat it, so the chip is shown only on the
+ * starting segment.
+ */
+export function getMonthEventDisplay(params: {
+  viewType: string;
+  allDay: boolean;
+  isTask: boolean;
+  start: Date | null;
+  isStart: boolean;
+  timeFormat: TimeFormat;
+}): MonthEventDisplay {
+  const { viewType, allDay, isTask, start, isStart, timeFormat } = params;
+
+  const isDayGridTimed =
+    isDayGridView(viewType) && !allDay && !isTask && start !== null;
+  // The colored dot and time only belong on the starting segment; the calendar
+  // identity (isDayGridTimed) applies to every colored segment.
+  const showTimeChip = isDayGridTimed && isStart;
+
+  return {
+    isDayGridTimed,
+    showTimeChip,
+    timeText: showTimeChip && start ? formatEventTime(start, timeFormat) : "",
+  };
+}


### PR DESCRIPTION
## Summary

Fixes #95. In month (and multi-month) view, **timed events** previously rendered only a generic clock icon - no start time, and no calendar color - which made them hard to scan next to the colored all-day events.

Timed, non-task events in day-grid views now render a **calendar-colored dot** (or a tinted recurrence icon) followed by their **start time**, formatted per the user's 12h/24h setting - mirroring the Nextcloud-style treatment requested in the issue.

Before: `🕐 Meeting`
After: `● 3:30 PM Meeting` (dot uses the calendar's color)

## What changed

- **`src/lib/calendar-event-display.ts`** (new): pure, unit-tested display logic - `formatEventTime`, `isDayGridView`, and `getMonthEventDisplay`. Follows the existing `calendar-drag.ts` pattern of keeping logic in a testable lib module.
- **`CalendarEventContent.tsx`**: renders the colored dot + time for timed day-grid events, reading the calendar color from the event and the 12h/24h preference from settings.
- **`MonthView.tsx` / `MultiMonthView.tsx`**: pass the calendar name through `extendedProps` for the accessible label.

## Scope / non-regression

- **Day/Week (time-grid) views are unchanged** - FullCalendar already shows the time and a colored block there; the new treatment is gated to day-grid views (`dayGridMonth`, `multiMonthYear`).
- **Tasks and all-day events** keep their existing rendering.
- **Multi-day timed events**: the time is shown only on the starting segment (gated on FullCalendar's `isStart`), so continuation segments don't repeat the start time.
- **Accessibility**: the colored dot is decorative; the calendar name is exposed as `sr-only` text on every timed day-grid segment, so calendar identity isn't conveyed by color alone.

## Testing

- New unit suite `src/__tests__/calendar-event-display.test.ts` - **18 tests**, written test-first (red → green), covering time formatting (12h/24h, midnight, noon, padding), view detection, and the timed-chip decision (all-day, task, time-grid, multi-month, multi-day continuation, missing start).
- `npm run type-check`: clean.
- `npm run lint`: clean.
- Pre-existing unrelated failures in `google-field-mapper` / `google-provider.unit` suites are present on `main` as well (timezone-dependent) and are untouched by this change.

Developed with TDD and an iterative Codex adversarial-review loop (final verdict: approve).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ta1fmwePeqQ6jbGMjXw4Nq