### PR TITLE
fix(settings): honor 12h/24h preference in Auto-Schedule time dropdowns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Auto-Schedule settings time dropdowns (Working Hours and energy-level ranges) now honor the 12h/24h preference from General settings instead of always showing 24-hour times (#129)
 - Improved all-day event UI by removing time selection when "All day" is checked, showing only date picker instead
 - Fixed Google Calendar event deletion by adding missing userId parameter for authentication
 - Fixed Outlook task sync issues with recurring tasks

--- a/src/__tests__/autoSchedule.test.ts
+++ b/src/__tests__/autoSchedule.test.ts
@@ -1,0 +1,53 @@
+import { formatTime } from "@/lib/autoSchedule";
+
+// Issue #129: the time-selection dropdowns in the Auto-Schedule settings tab
+// (Working Hours start/end, energy-level ranges) must honor the user's 12h/24h
+// preference from General settings instead of always rendering 24-hour times.
+
+describe("formatTime", () => {
+  describe("24-hour format", () => {
+    it("zero-pads a morning hour", () => {
+      expect(formatTime(9, "24h")).toBe("09:00");
+    });
+
+    it("renders an evening hour as 24-hour time", () => {
+      expect(formatTime(20, "24h")).toBe("20:00");
+    });
+
+    it("renders midnight as 00:00", () => {
+      expect(formatTime(0, "24h")).toBe("00:00");
+    });
+
+    it("renders noon as 12:00", () => {
+      expect(formatTime(12, "24h")).toBe("12:00");
+    });
+  });
+
+  describe("12-hour format", () => {
+    it("renders an evening hour with a PM suffix", () => {
+      expect(formatTime(20, "12h")).toBe("8:00 PM");
+    });
+
+    it("renders a morning hour with an AM suffix", () => {
+      expect(formatTime(9, "12h")).toBe("9:00 AM");
+    });
+
+    it("renders midnight as 12:00 AM", () => {
+      expect(formatTime(0, "12h")).toBe("12:00 AM");
+    });
+
+    it("renders noon as 12:00 PM", () => {
+      expect(formatTime(12, "12h")).toBe("12:00 PM");
+    });
+
+    it("renders 11 PM correctly", () => {
+      expect(formatTime(23, "12h")).toBe("11:00 PM");
+    });
+  });
+
+  describe("default behavior", () => {
+    it("defaults to 24-hour format when no preference is given", () => {
+      expect(formatTime(20)).toBe("20:00");
+    });
+  });
+});

--- a/src/components/settings/AutoScheduleSettings.tsx
+++ b/src/components/settings/AutoScheduleSettings.tsx
@@ -25,7 +25,7 @@ import { useSettingsStore } from "@/store/settings";
 import { SettingRow, SettingsSection } from "./SettingsSection";
 
 export function AutoScheduleSettings() {
-  const { autoSchedule, updateAutoScheduleSettings } = useSettingsStore();
+  const { autoSchedule, updateAutoScheduleSettings, user } = useSettingsStore();
   const { feeds, loadFromDatabase } = useCalendarStore();
 
   // Load calendar feeds when component mounts
@@ -45,7 +45,7 @@ export function AutoScheduleSettings() {
 
   const timeOptions = Array.from({ length: 24 }, (_, i) => ({
     value: i,
-    label: formatTime(i),
+    label: formatTime(i, user.timeFormat),
   }));
 
   const selectedCalendars = parseSelectedCalendars(

--- a/src/lib/autoSchedule.ts
+++ b/src/lib/autoSchedule.ts
@@ -1,4 +1,4 @@
-import { AutoScheduleSettings } from "@/types/settings";
+import { AutoScheduleSettings, TimeFormat } from "@/types/settings";
 
 export function parseWorkDays(workDays: string): number[] {
   try {
@@ -24,7 +24,21 @@ export function stringifySelectedCalendars(calendars: string[]): string {
   return JSON.stringify(calendars);
 }
 
-export function formatTime(hour: number): string {
+/**
+ * Format a whole-hour value (0-23) for the Auto-Schedule time dropdowns,
+ * honoring the user's 12h/24h preference from General settings (issue #129).
+ * Defaults to 24-hour so callers without a preference keep the prior output.
+ */
+export function formatTime(
+  hour: number,
+  timeFormat: TimeFormat = "24h"
+): string {
+  if (timeFormat === "12h") {
+    const period = hour >= 12 ? "PM" : "AM";
+    const h12 = hour % 12 === 0 ? 12 : hour % 12;
+    return `${h12}:00 ${period}`;
+  }
+
   return `${hour.toString().padStart(2, "0")}:00`;
 }
 


### PR DESCRIPTION
## Summary

Fixes #129. In the Auto-Schedule settings tab, the time-selection dropdowns (Working Hours start/end and the High/Medium/Low energy-level ranges) always rendered times in 24-hour format, ignoring the user's 12h/24h preference from General settings. The reporter specifically called out the End Time field showing a 24-hour clock when 12-hour was selected.

Root cause: `formatTime()` in `src/lib/autoSchedule.ts` hardcoded the `HH:00` (24-hour) output, and `AutoScheduleSettings` built its dropdown labels from it without passing any format preference.

## Changes

- `src/lib/autoSchedule.ts`: `formatTime(hour, timeFormat?)` now accepts an optional `TimeFormat` and renders 12-hour labels (e.g. `8:00 PM`, `12:00 AM`, `12:00 PM`) when the user selected `12h`. It defaults to `24h` so existing callers are unchanged. The underlying `0-23` option values are untouched, so stored settings and scheduling logic are unaffected.
- `src/components/settings/AutoScheduleSettings.tsx`: reads `user` from the settings store and passes `user.timeFormat` into the dropdown labels. This covers every time dropdown in the tab (Working Hours start/end and all energy-level selects), not just End Time, since they share the same helper.
- `CHANGELOG.md`: added a `Fixed` entry under `[Unreleased]`.

## Test plan

- New unit suite `src/__tests__/autoSchedule.test.ts` covers `formatTime` for both formats including edge cases (midnight, noon, evening) and the 24h default. Result: 10/10 pass.
- `npm run type-check`: passes.
- `npm run lint`: passes (no warnings/errors).
- Manual: General settings -> Time Format = 12-hour -> Auto-Schedule tab -> Working Hours End Time now shows `8:00 PM` instead of `20:00`; switching to 24-hour shows `20:00`.

Note on the full unit suite: two pre-existing suites unrelated to this change (`google-field-mapper.test.ts`, `google-provider.unit.test.ts`, 6 tests) fail on a clean `main` as well; they concern Google task field mapping and are out of scope for this issue, so they were left untouched.

## Codex review

Codex `adversarial-review` (branch vs `main`) returned `verdict: approve` with zero findings on the first round. Its only note was that Jest could not write its haste-map cache in the read-only review sandbox; the suite passes in the writable environment (10/10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mqdsn2va7teLRuNPdyeZy