### PR TITLE
feat(api): public /api/v1 for task & event creation and scheduling

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,158 @@
+# FluidCalendar API Reference (v1)
+
+Programmatic access to your tasks and calendar so external tools — automation
+platforms (Zapier/n8n), meeting assistants, scripts, or your own apps — can
+create items and let FluidCalendar's auto-scheduler position your todos.
+
+- **Base URL:** `https://<your-instance>/api/v1`
+- **Versioning:** in the URL path (`/api/v1`). Breaking changes ship under a new
+  version; `v1` stays stable.
+
+## Authentication
+
+1. In FluidCalendar, open **Settings → API & Developer** and turn on
+   **Enable API access** (off by default).
+2. Click **Create key**, give it a name, and copy the key. The full key is shown
+   **once** and never again — store it somewhere safe.
+3. Send it as a bearer token on every request:
+
+```bash
+curl https://<your-instance>/api/v1/tasks \
+  -H "Authorization: Bearer fcal_xxxxxxxxxxxxxxxx_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+```
+
+Keys look like `fcal_<prefix>_<secret>`. Only a SHA-256 hash is stored server
+side. Revoke a key any time from the same settings page; disabling **Enable API
+access** rejects all of your keys at once without deleting them.
+
+> Key-management endpoints (creating/revoking keys, the enable toggle) are
+> intentionally **not** reachable with an API key — they require a logged-in
+> session, so a leaked key cannot mint more keys.
+
+## Conventions
+
+**Errors** use a consistent envelope:
+
+```json
+{ "error": { "code": "INVALID_ARGUMENT", "message": "title is required", "field": "title" } }
+```
+
+| Code | HTTP | Meaning |
+|------|------|---------|
+| `UNAUTHORIZED` | 401 | Missing/invalid key or session |
+| `FORBIDDEN` | 403 | API access not enabled for the account |
+| `INVALID_ARGUMENT` | 400 | Malformed/invalid request body |
+| `NOT_FOUND` | 404 | Resource not found (or not yours) |
+| `RATE_LIMITED` | 429 | Too many requests — see `Retry-After` |
+| `INTERNAL` | 500 | Unexpected server error |
+
+**Pagination** (list endpoints) is cursor-based:
+
+```json
+{ "data": [ ... ], "next_cursor": "abc123", "has_more": true }
+```
+
+Pass `?cursor=<next_cursor>&limit=50` to page (default `limit` 50, max 500).
+
+**Rate limiting:** every response carries `X-RateLimit-Limit`,
+`X-RateLimit-Remaining`, and `X-RateLimit-Reset`. On 429 a `Retry-After`
+(seconds) header is included. The scheduling path is limited more tightly than
+reads/writes because a replan is expensive.
+
+**Idempotency:** include an `Idempotency-Key` header on write requests. The
+first successful response is stored and replayed for any retry with the same
+key, so a flaky network or a re-fired webhook can't double-create.
+
+## Tasks
+
+### `POST /api/v1/tasks`
+
+Create one task or a batch. Send a single object **or an array** of them.
+
+Fields: `title` (required), `description`, `duration` (minutes, default 30),
+`priority`, `energyLevel`, `preferredTime`, `dueDate`, `projectId`, `tagIds`,
+`recurrenceRule` (RRULE string).
+
+To have FluidCalendar auto-position a task, include an `autoScheduled` object:
+
+```json
+{
+  "title": "Follow up with Clay",
+  "duration": 30,
+  "autoScheduled": { "deadline": "2026-06-25T17:00:00Z", "deadlineType": "SOFT" }
+}
+```
+
+`deadlineType` is `HARD`, `SOFT`, or `NONE`. When any item in the request is
+`autoScheduled`, the scheduler runs **once** for the whole batch and the
+response includes each task's booked `scheduledStart` / `scheduledEnd`.
+
+> **Timezone:** auto-scheduling requires your account to have a timezone set
+> (Settings → User) and auto-schedule configured. Otherwise the request returns
+> 400 — we won't guess and risk placing tasks in the wrong timezone.
+
+```bash
+# A meeting's worth of todos in one call, auto-scheduled
+curl -X POST https://<your-instance>/api/v1/tasks \
+  -H "Authorization: Bearer $FCAL_KEY" \
+  -H "Content-Type: application/json" \
+  -H "Idempotency-Key: mtg-2026-06-21-001" \
+  -d '[
+    {"title":"Send recap deck","duration":45,"autoScheduled":{"deadlineType":"SOFT"}},
+    {"title":"Email Dr. Rob","duration":15,"autoScheduled":{"deadlineType":"SOFT"}}
+  ]'
+```
+
+### `GET /api/v1/tasks`
+
+List your tasks. Query: `cursor`, `limit`, `status`. Returns a paginated list.
+
+### `GET|PATCH|DELETE /api/v1/tasks/{id}`
+
+Read, update, or delete one of your tasks. `PATCH` accepts any subset of the
+create fields. Returns 404 for an id that isn't yours.
+
+## Events
+
+Events are fixed-time calendar entries (not auto-scheduled).
+
+### `POST /api/v1/events`
+
+Create one event or a batch. Fields: `title`, `start`, `end` (required;
+`end` must be after `start`), `description`, `location`, `allDay`,
+`isRecurring`, `recurrenceRule`. You do **not** pass a calendar id — events land
+on your local calendar automatically.
+
+```bash
+curl -X POST https://<your-instance>/api/v1/events \
+  -H "Authorization: Bearer $FCAL_KEY" -H "Content-Type: application/json" \
+  -d '{"title":"Sync with Clay","start":"2026-06-24T15:00:00Z","end":"2026-06-24T15:30:00Z"}'
+```
+
+### `GET /api/v1/events`
+
+List your events. Query: `from`, `to` (ISO range), `cursor`, `limit`.
+
+### `GET|PATCH|DELETE /api/v1/events/{id}`
+
+Read, update, or delete one of your events. Returns 404 for an id that isn't
+yours.
+
+## Scheduling
+
+### `POST /api/v1/schedule`
+
+Trigger a full replan of your auto-scheduled tasks (the same thing
+`autoScheduled` does on create, run on demand). Returns the count and the
+re-positioned tasks. Rate-limited more tightly than other endpoints.
+
+```bash
+curl -X POST https://<your-instance>/api/v1/schedule -H "Authorization: Bearer $FCAL_KEY"
+```
+
+## Roadmap (not in v1 yet)
+
+`/api/v1/sync` (incremental sync + batched commands for offline apps), projects
+/ tags / settings resources, a first-party mobile OAuth flow, granular per-key
+scopes, structured (non-RRULE) recurrence, and an OpenAPI spec. None of these
+will break the v1 contract above.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -49,6 +49,12 @@ Keys look like `fcal_<prefix>_<secret>`. Only a SHA-256 hash is stored server
 side. Revoke a key any time from the same settings page; disabling **Enable API
 access** rejects all of your keys at once without deleting them.
 
+> **Send keys over HTTPS only.** An API key is a bearer credential — anyone with
+> it can act as you. Always call the API over `https://`. FluidCalendar is meant
+> to run behind a TLS-terminating reverse proxy (the hosted instance uses one
+> that redirects HTTP→HTTPS); if you self-host, put it behind HTTPS and never
+> send a key over plaintext HTTP.
+
 > Key-management endpoints (creating/revoking keys, the enable toggle) are
 > intentionally **not** reachable with an API key — they require a logged-in
 > session, so a leaked key cannot mint more keys.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -131,7 +131,9 @@ curl -X POST https://<your-instance>/api/v1/events \
 
 ### `GET /api/v1/events`
 
-List your events. Query: `from`, `to` (ISO range), `cursor`, `limit`.
+List your events. Query: `from`, `to` (ISO range), `cursor`, `limit`. Queries are
+bounded to a window of **1 week in the past to 2 years ahead** (a wider `from`/`to`
+is clamped to that window); the 1-week look-back is a timezone-offset-safe buffer.
 
 ### `GET|PATCH|DELETE /api/v1/events/{id}`
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -8,6 +8,30 @@ create items and let FluidCalendar's auto-scheduler position your todos.
 - **Versioning:** in the URL path (`/api/v1`). Breaking changes ship under a new
   version; `v1` stays stable.
 
+## Design principles & standards
+
+Good design by default — we follow established standards so the API behaves the
+way an experienced integrator expects, with no surprises:
+
+- **Dates & times — RFC 3339 (the API profile of ISO 8601).** Every timestamp
+  you send must be a well-formed RFC 3339 value with an explicit offset, e.g.
+  `2026-06-24T15:00:00Z` or `2026-06-24T17:00:00+02:00`; a bare calendar date
+  (`2026-06-24`) is accepted as UTC midnight. Loose inputs (`"tomorrow"`,
+  `06/24/2026`, an offset-less time, an impossible date) are **rejected with a
+  400** rather than silently misinterpreted. We store everything in **UTC** and
+  always return timestamps as ISO-8601 UTC (`…Z`), so the caller does the
+  timezone math once, at the edge.
+- **Recurrence — iCalendar RRULE (RFC 5545).** `recurrenceRule` is a standard
+  RRULE string (e.g. `FREQ=WEEKLY;BYDAY=MO,WE`), the same grammar used by Google
+  Calendar, CalDAV, and `.ics` files.
+- **Intervals are half-open `[start, end)`** and `allDay` events are flagged
+  explicitly via the `allDay` field.
+- **UTC storage, offset-aware input** — send any offset; we normalize.
+
+Mechanical HTTP conventions (errors, pagination, rate-limit headers,
+idempotency) are in [Conventions](#conventions) below; they follow the same
+"match the prevailing standard" rule.
+
 ## Authentication
 
 1. In FluidCalendar, open **Settings → API & Developer** and turn on

--- a/prisma/migrations/20260621180000_add_api_keys/migration.sql
+++ b/prisma/migrations/20260621180000_add_api_keys/migration.sql
@@ -1,0 +1,69 @@
+-- Programmatic API access (issue #160): API keys, per-user enable gate, idempotency store.
+
+-- CreateTable
+CREATE TABLE "ApiKey" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "keyPrefix" TEXT NOT NULL,
+    "hashedKey" TEXT NOT NULL,
+    "lastUsedAt" TIMESTAMP(3),
+    "expiresAt" TIMESTAMP(3),
+    "revokedAt" TIMESTAMP(3),
+    "scopes" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ApiKey_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ApiSettings" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "enabled" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ApiSettings_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "IdempotencyKey" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "key" TEXT NOT NULL,
+    "route" TEXT NOT NULL,
+    "statusCode" INTEGER NOT NULL,
+    "responseJson" JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "IdempotencyKey_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ApiKey_keyPrefix_key" ON "ApiKey"("keyPrefix");
+
+-- CreateIndex
+CREATE INDEX "ApiKey_keyPrefix_idx" ON "ApiKey"("keyPrefix");
+
+-- CreateIndex
+CREATE INDEX "ApiKey_userId_idx" ON "ApiKey"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ApiSettings_userId_key" ON "ApiSettings"("userId");
+
+-- CreateIndex
+CREATE INDEX "IdempotencyKey_createdAt_idx" ON "IdempotencyKey"("createdAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "IdempotencyKey_userId_key_key" ON "IdempotencyKey"("userId", "key");
+
+-- AddForeignKey
+ALTER TABLE "ApiKey" ADD CONSTRAINT "ApiKey_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ApiSettings" ADD CONSTRAINT "ApiSettings_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "IdempotencyKey" ADD CONSTRAINT "IdempotencyKey_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -85,6 +85,9 @@ model User {
   taskProviders        TaskProvider[]
   TaskChange           TaskChange[]
   PasswordReset        PasswordReset[]
+  apiKeys              ApiKey[]
+  apiSettings          ApiSettings?
+  idempotencyKeys      IdempotencyKey[]
 }
 
 model VerificationToken {
@@ -644,4 +647,48 @@ model Subscription {
 
   @@index([stripeCustomerId])
   @@index([stripePaymentIntentId])
+}
+
+// Programmatic API access (issue #160). API keys authenticate requests on /api/v1 only.
+model ApiKey {
+  id         String    @id @default(cuid())
+  userId     String
+  user       User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  name       String
+  keyPrefix  String    @unique // public, indexed lookup id parsed from the token
+  hashedKey  String // SHA-256 of the full key; constant-time compared in auth
+  lastUsedAt DateTime?
+  expiresAt  DateTime? // null = never expires
+  revokedAt  DateTime? // soft-delete; active when null
+  scopes     Json? // reserved for Phase 2 granular permissions; null = full access
+  createdAt  DateTime  @default(now())
+  updatedAt  DateTime  @updatedAt
+
+  @@index([keyPrefix])
+  @@index([userId])
+}
+
+// Per-user master switch for programmatic API access. Default-deny.
+model ApiSettings {
+  id        String   @id @default(cuid())
+  userId    String   @unique
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  enabled   Boolean  @default(false)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+
+// Replay-safe writes: stores the first response for an Idempotency-Key per user. TTL-pruned.
+model IdempotencyKey {
+  id           String   @id @default(cuid())
+  userId       String
+  user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  key          String
+  route        String
+  statusCode   Int
+  responseJson Json
+  createdAt    DateTime @default(now())
+
+  @@unique([userId, key])
+  @@index([createdAt])
 }

--- a/src/app/(common)/settings/page.tsx
+++ b/src/app/(common)/settings/page.tsx
@@ -6,6 +6,7 @@ import { Suspense } from "react";
 import dynamic from "next/dynamic";
 
 import { AccountManager } from "@/components/settings/AccountManager";
+import { ApiSettings } from "@/components/settings/ApiSettings";
 import { AutoScheduleSettings } from "@/components/settings/AutoScheduleSettings";
 import { CalendarSettings } from "@/components/settings/CalendarSettings";
 import { ImportExportSettings } from "@/components/settings/ImportExportSettings";
@@ -52,7 +53,8 @@ type SettingsTab =
   | "waitlist"
   | "import-export"
   | "admin-dashboard"
-  | "notifications";
+  | "notifications"
+  | "developer";
 
 export default function SettingsPage() {
   const [isHydrated, setIsHydrated] = useState(false);
@@ -73,6 +75,7 @@ export default function SettingsPage() {
       { id: "task-sync", label: "Task Sync" },
       { id: "notifications", label: "Notifications" },
       { id: "import-export", label: "Import/Export" },
+      { id: "developer", label: "API & Developer" },
     ] as const;
 
     // Add admin-only tabs
@@ -120,6 +123,7 @@ export default function SettingsPage() {
         "import-export",
         "admin-dashboard",
         "notifications",
+        "developer",
       ];
 
       if (allPossibleTabIds.includes(hash)) {
@@ -199,6 +203,8 @@ export default function SettingsPage() {
         return <UserManagement />;
       case "import-export":
         return <ImportExportSettings />;
+      case "developer":
+        return <ApiSettings />;
       case "waitlist":
         return (
           <Suspense fallback={<div>Loading...</div>}>

--- a/src/app/api/api-keys/[id]/__tests__/route.test.ts
+++ b/src/app/api/api-keys/[id]/__tests__/route.test.ts
@@ -1,0 +1,112 @@
+import { NextResponse } from "next/server";
+import { NextRequest } from "next/server";
+
+import { authenticateRequest } from "@/lib/auth/api-auth";
+import { prisma } from "@/lib/prisma";
+
+// Mock dependencies
+jest.mock("@/lib/auth/api-auth");
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    apiKey: {
+      updateMany: jest.fn(),
+    },
+  },
+}));
+jest.mock("@/lib/logger");
+
+// Import route handler after mocking
+import { DELETE } from "../route";
+
+const mockAuthenticateRequest = authenticateRequest as unknown as jest.Mock;
+const mockPrisma = prisma as unknown as Record<string, Record<string, jest.Mock>>;
+
+describe("DELETE /api/api-keys/[id]", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("revokes a key by setting revokedAt", async () => {
+    mockAuthenticateRequest.mockResolvedValue({ userId: "u1" });
+    mockPrisma.apiKey.updateMany.mockResolvedValue({ count: 1 });
+
+    const request = { headers: new Headers() } as unknown as NextRequest;
+    const params = Promise.resolve({ id: "k1" });
+
+    const res = (await DELETE(request, { params })) as NextResponse;
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.revoked).toBe(true);
+    expect(body.id).toBe("k1");
+  });
+
+  it("sets revokedAt to now when revoking", async () => {
+    mockAuthenticateRequest.mockResolvedValue({ userId: "u1" });
+    mockPrisma.apiKey.updateMany.mockResolvedValue({ count: 1 });
+
+    const request = { headers: new Headers() } as unknown as NextRequest;
+    const params = Promise.resolve({ id: "k1" });
+
+    await DELETE(request, { params });
+
+    const updateCall = mockPrisma.apiKey.updateMany.mock.calls[0];
+    expect(updateCall[0].data.revokedAt).toBeInstanceOf(Date);
+  });
+
+  it("scopes revoke to userId to prevent cross-user revocation", async () => {
+    mockAuthenticateRequest.mockResolvedValue({ userId: "u1" });
+    mockPrisma.apiKey.updateMany.mockResolvedValue({ count: 1 });
+
+    const request = { headers: new Headers() } as unknown as NextRequest;
+    const params = Promise.resolve({ id: "k1" });
+
+    await DELETE(request, { params });
+
+    const updateCall = mockPrisma.apiKey.updateMany.mock.calls[0];
+    expect(updateCall[0].where).toEqual({
+      id: "k1",
+      userId: "u1",
+      revokedAt: null,
+    });
+  });
+
+  it("returns 404 if key not found or already revoked", async () => {
+    mockAuthenticateRequest.mockResolvedValue({ userId: "u1" });
+    mockPrisma.apiKey.updateMany.mockResolvedValue({ count: 0 });
+
+    const request = { headers: new Headers() } as unknown as NextRequest;
+    const params = Promise.resolve({ id: "nonexistent" });
+
+    const res = (await DELETE(request, { params })) as NextResponse;
+
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toContain("not found");
+  });
+
+  it("returns 404 if count is 0", async () => {
+    mockAuthenticateRequest.mockResolvedValue({ userId: "u1" });
+    mockPrisma.apiKey.updateMany.mockResolvedValue({ count: 0 });
+
+    const request = { headers: new Headers() } as unknown as NextRequest;
+    const params = Promise.resolve({ id: "k1" });
+
+    const res = (await DELETE(request, { params })) as NextResponse;
+
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 401 if not authenticated", async () => {
+    mockAuthenticateRequest.mockResolvedValue({
+      response: { status: 401, json: async () => ({ error: "Unauthorized" }) },
+    });
+
+    const request = { headers: new Headers() } as unknown as NextRequest;
+    const params = Promise.resolve({ id: "k1" });
+
+    const res = (await DELETE(request, { params })) as NextResponse;
+
+    expect(res.status).toBe(401);
+  });
+});

--- a/src/app/api/api-keys/[id]/route.ts
+++ b/src/app/api/api-keys/[id]/route.ts
@@ -1,0 +1,69 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { authenticateRequest } from "@/lib/auth/api-auth";
+import { logger } from "@/lib/logger";
+import { prisma } from "@/lib/prisma";
+
+const LOG_SOURCE = "ApiKeysDeleteRoute";
+
+/**
+ * DELETE /api/api-keys/[id] — Revoke an API key (soft-delete).
+ *
+ * Sets revokedAt to now. Only the owning user can revoke their own key.
+ * Returns 404 if the key doesn't exist or doesn't belong to the user.
+ * Returns { revoked: true, id }.
+ */
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const auth = await authenticateRequest(request, LOG_SOURCE);
+    if ("response" in auth) {
+      return auth.response;
+    }
+
+    const userId = auth.userId;
+    const { id } = await params;
+
+    // Soft-revoke: set revokedAt to now, scoped to userId
+    const result = await prisma.apiKey.updateMany({
+      where: {
+        id,
+        userId,
+        revokedAt: null,
+      },
+      data: {
+        revokedAt: new Date(),
+      },
+    });
+
+    if (result.count === 0) {
+      return NextResponse.json(
+        { error: "API key not found" },
+        { status: 404 }
+      );
+    }
+
+    logger.info(
+      "Revoked API key",
+      { userId, keyId: id },
+      LOG_SOURCE
+    );
+
+    return NextResponse.json({
+      revoked: true,
+      id,
+    });
+  } catch (error) {
+    logger.error(
+      "Failed to revoke API key",
+      { error: error instanceof Error ? error.message : "Unknown error" },
+      LOG_SOURCE
+    );
+    return NextResponse.json(
+      { error: "Failed to revoke API key" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/api-keys/__tests__/route.test.ts
+++ b/src/app/api/api-keys/__tests__/route.test.ts
@@ -1,0 +1,260 @@
+import { NextResponse } from "next/server";
+import { NextRequest } from "next/server";
+
+import { authenticateRequest } from "@/lib/auth/api-auth";
+import { generateApiKey } from "@/lib/auth/api-key";
+import { prisma } from "@/lib/prisma";
+
+// Mock dependencies
+jest.mock("@/lib/auth/api-auth");
+jest.mock("@/lib/auth/api-key");
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    apiKey: {
+      findMany: jest.fn(),
+      create: jest.fn(),
+    },
+  },
+}));
+jest.mock("@/lib/logger");
+
+// Import route handlers after mocking
+import { GET, POST } from "../route";
+
+const mockAuthenticateRequest = authenticateRequest as unknown as jest.Mock;
+const mockGenerateApiKey = generateApiKey as unknown as jest.Mock;
+const mockPrisma = prisma as unknown as Record<string, Record<string, jest.Mock>>;
+
+describe("GET /api/api-keys", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns list of user's keys with metadata only", async () => {
+    const mockKeys = [
+      {
+        id: "k1",
+        name: "Production",
+        keyPrefix: "abc123",
+        lastUsedAt: new Date("2025-01-01"),
+        expiresAt: null,
+        revokedAt: null,
+        createdAt: new Date("2024-12-01"),
+      },
+    ];
+
+    mockAuthenticateRequest.mockResolvedValue({ userId: "u1" });
+    mockPrisma.apiKey.findMany.mockResolvedValue(mockKeys);
+
+    const request = { headers: new Headers() } as unknown as NextRequest;
+    const res = (await GET(request)) as NextResponse;
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    // Compare the structure, dates are serialized to ISO strings in JSON
+    expect(body.keys.length).toBe(1);
+    expect(body.keys[0].id).toBe("k1");
+    expect(body.keys[0].name).toBe("Production");
+    expect(body.keys[0].keyPrefix).toBe("abc123");
+    expect(mockPrisma.apiKey.findMany).toHaveBeenCalledWith({
+      where: { userId: "u1" },
+      select: {
+        id: true,
+        name: true,
+        keyPrefix: true,
+        lastUsedAt: true,
+        expiresAt: true,
+        revokedAt: true,
+        createdAt: true,
+      },
+      orderBy: { createdAt: "desc" },
+    });
+  });
+
+  it("returns 401 if not authenticated", async () => {
+    mockAuthenticateRequest.mockResolvedValue({
+      response: { status: 401, json: async () => ({ error: "Unauthorized" }) },
+    });
+
+    const request = { headers: new Headers() } as unknown as NextRequest;
+    const res = (await GET(request)) as NextResponse;
+
+    expect(res.status).toBe(401);
+  });
+
+  it("never returns hashedKey or fullKey", async () => {
+    const mockKeys = [
+      {
+        id: "k1",
+        name: "Test",
+        keyPrefix: "prefix",
+        lastUsedAt: null,
+        expiresAt: null,
+        revokedAt: null,
+        createdAt: new Date(),
+      },
+    ];
+
+    mockAuthenticateRequest.mockResolvedValue({ userId: "u1" });
+    mockPrisma.apiKey.findMany.mockResolvedValue(mockKeys);
+
+    const request = { headers: new Headers() } as unknown as NextRequest;
+    const res = (await GET(request)) as NextResponse;
+    const body = await res.json();
+
+    expect(body.keys[0]).not.toHaveProperty("hashedKey");
+    expect(body.keys[0]).not.toHaveProperty("fullKey");
+  });
+});
+
+describe("POST /api/api-keys", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("creates an API key and returns plaintext key once", async () => {
+    const mockFullKey = "fcal_abc123_secret";
+    const mockKeyData = {
+      id: "k1",
+      name: "Production",
+      keyPrefix: "abc123",
+      createdAt: new Date(),
+    };
+
+    mockAuthenticateRequest.mockResolvedValue({ userId: "u1" });
+    mockGenerateApiKey.mockReturnValue({
+      fullKey: mockFullKey,
+      keyPrefix: "abc123",
+      hashedKey: "hashed...",
+    });
+    mockPrisma.apiKey.create.mockResolvedValue(mockKeyData);
+
+    const request = {
+      headers: new Headers({ "content-type": "application/json" }),
+      json: async () => ({ name: "Production" }),
+    } as unknown as NextRequest;
+
+    const res = (await POST(request)) as NextResponse;
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.key).toBe(mockFullKey);
+    expect(body.id).toBe("k1");
+    expect(body.name).toBe("Production");
+    expect(body.keyPrefix).toBe("abc123");
+  });
+
+  it("stores hashedKey but returns plaintext key", async () => {
+    mockAuthenticateRequest.mockResolvedValue({ userId: "u1" });
+    mockGenerateApiKey.mockReturnValue({
+      fullKey: "fcal_abc123_secret",
+      keyPrefix: "abc123",
+      hashedKey: "hashed_value",
+    });
+    mockPrisma.apiKey.create.mockResolvedValue({
+      id: "k1",
+      name: "Test",
+      keyPrefix: "abc123",
+      createdAt: new Date(),
+    });
+
+    const request = {
+      headers: new Headers({ "content-type": "application/json" }),
+      json: async () => ({ name: "Test" }),
+    } as unknown as NextRequest;
+
+    await POST(request);
+
+    // Verify create was called with hashedKey
+    const createCall = mockPrisma.apiKey.create.mock.calls[0];
+    expect(createCall[0].data.hashedKey).toBe("hashed_value");
+  });
+
+  it("rejects empty name", async () => {
+    mockAuthenticateRequest.mockResolvedValue({ userId: "u1" });
+
+    const request = {
+      headers: new Headers({ "content-type": "application/json" }),
+      json: async () => ({ name: "" }),
+    } as unknown as NextRequest;
+
+    const res = (await POST(request)) as NextResponse;
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("name is required");
+  });
+
+  it("rejects name longer than 100 chars", async () => {
+    mockAuthenticateRequest.mockResolvedValue({ userId: "u1" });
+
+    const longName = "a".repeat(101);
+    const request = {
+      headers: new Headers({ "content-type": "application/json" }),
+      json: async () => ({ name: longName }),
+    } as unknown as NextRequest;
+
+    const res = (await POST(request)) as NextResponse;
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("100 characters");
+  });
+
+  it("accepts optional expiresAt as ISO8601", async () => {
+    const expiresAt = "2025-12-31T23:59:59Z";
+    mockAuthenticateRequest.mockResolvedValue({ userId: "u1" });
+    mockGenerateApiKey.mockReturnValue({
+      fullKey: "fcal_abc123_secret",
+      keyPrefix: "abc123",
+      hashedKey: "hashed...",
+    });
+    mockPrisma.apiKey.create.mockResolvedValue({
+      id: "k1",
+      name: "Temporary",
+      keyPrefix: "abc123",
+      createdAt: new Date(),
+    });
+
+    const request = {
+      headers: new Headers({ "content-type": "application/json" }),
+      json: async () => ({ name: "Temporary", expiresAt }),
+    } as unknown as NextRequest;
+
+    const res = (await POST(request)) as NextResponse;
+
+    expect(res.status).toBe(201);
+    const createCall = mockPrisma.apiKey.create.mock.calls[0];
+    expect(createCall[0].data.expiresAt).toEqual(new Date(expiresAt));
+  });
+
+  it("rejects invalid expiresAt date", async () => {
+    mockAuthenticateRequest.mockResolvedValue({ userId: "u1" });
+
+    const request = {
+      headers: new Headers({ "content-type": "application/json" }),
+      json: async () => ({ name: "Test", expiresAt: "not-a-date" }),
+    } as unknown as NextRequest;
+
+    const res = (await POST(request)) as NextResponse;
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("ISO8601");
+  });
+
+  it("returns 401 if not authenticated", async () => {
+    mockAuthenticateRequest.mockResolvedValue({
+      response: { status: 401, json: async () => ({ error: "Unauthorized" }) },
+    });
+
+    const request = {
+      headers: new Headers({ "content-type": "application/json" }),
+      json: async () => ({ name: "Test" }),
+    } as unknown as NextRequest;
+
+    const res = (await POST(request)) as NextResponse;
+
+    expect(res.status).toBe(401);
+  });
+});

--- a/src/app/api/api-keys/route.ts
+++ b/src/app/api/api-keys/route.ts
@@ -1,0 +1,146 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { authenticateRequest } from "@/lib/auth/api-auth";
+import { generateApiKey } from "@/lib/auth/api-key";
+import { logger } from "@/lib/logger";
+import { prisma } from "@/lib/prisma";
+
+const LOG_SOURCE = "ApiKeysRoute";
+
+/**
+ * GET /api/api-keys — List the user's API keys (metadata only).
+ *
+ * Returns keys with id, name, keyPrefix, lastUsedAt, expiresAt, revokedAt, createdAt.
+ * Never includes hashedKey or fullKey.
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const auth = await authenticateRequest(request, LOG_SOURCE);
+    if ("response" in auth) {
+      return auth.response;
+    }
+
+    const userId = auth.userId;
+
+    const keys = await prisma.apiKey.findMany({
+      where: { userId },
+      select: {
+        id: true,
+        name: true,
+        keyPrefix: true,
+        lastUsedAt: true,
+        expiresAt: true,
+        revokedAt: true,
+        createdAt: true,
+      },
+      orderBy: { createdAt: "desc" },
+    });
+
+    return NextResponse.json({ keys });
+  } catch (error) {
+    logger.error(
+      "Failed to list API keys",
+      { error: error instanceof Error ? error.message : "Unknown error" },
+      LOG_SOURCE
+    );
+    return NextResponse.json(
+      { error: "Failed to list API keys" },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * POST /api/api-keys — Create a new API key.
+ *
+ * Body: { name: string, expiresAt?: ISO8601 }
+ * Validates name is non-empty and <= 100 chars.
+ * Returns the plaintext key ONCE; stores only the hash.
+ * Returns 201 with { id, name, keyPrefix, createdAt, key }.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const auth = await authenticateRequest(request, LOG_SOURCE);
+    if ("response" in auth) {
+      return auth.response;
+    }
+
+    const userId = auth.userId;
+    const body = await request.json();
+    const { name, expiresAt } = body;
+
+    // Validate name
+    if (!name || typeof name !== "string" || name.trim() === "") {
+      return NextResponse.json(
+        { error: "name is required and must be a non-empty string" },
+        { status: 400 }
+      );
+    }
+
+    if (name.length > 100) {
+      return NextResponse.json(
+        { error: "name must be 100 characters or less" },
+        { status: 400 }
+      );
+    }
+
+    // Generate the API key
+    const { fullKey, keyPrefix, hashedKey } = generateApiKey();
+
+    // Parse and validate expiresAt if provided
+    let expiresAtDate: Date | undefined;
+    if (expiresAt) {
+      expiresAtDate = new Date(expiresAt);
+      if (isNaN(expiresAtDate.getTime())) {
+        return NextResponse.json(
+          { error: "expiresAt must be a valid ISO8601 date" },
+          { status: 400 }
+        );
+      }
+    }
+
+    // Create the API key record
+    const apiKey = await prisma.apiKey.create({
+      data: {
+        userId,
+        name: name.trim(),
+        keyPrefix,
+        hashedKey,
+        expiresAt: expiresAtDate,
+      },
+      select: {
+        id: true,
+        name: true,
+        keyPrefix: true,
+        createdAt: true,
+      },
+    });
+
+    logger.info(
+      "Created API key",
+      { userId, keyId: apiKey.id },
+      LOG_SOURCE
+    );
+
+    return NextResponse.json(
+      {
+        id: apiKey.id,
+        name: apiKey.name,
+        keyPrefix: apiKey.keyPrefix,
+        createdAt: apiKey.createdAt,
+        key: fullKey,
+      },
+      { status: 201 }
+    );
+  } catch (error) {
+    logger.error(
+      "Failed to create API key",
+      { error: error instanceof Error ? error.message : "Unknown error" },
+      LOG_SOURCE
+    );
+    return NextResponse.json(
+      { error: "Failed to create API key" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/api-settings/__tests__/route.test.ts
+++ b/src/app/api/api-settings/__tests__/route.test.ts
@@ -1,0 +1,151 @@
+import { NextResponse } from "next/server";
+import { NextRequest } from "next/server";
+
+import { authenticateRequest } from "@/lib/auth/api-auth";
+import { prisma } from "@/lib/prisma";
+
+// Mock dependencies
+jest.mock("@/lib/auth/api-auth");
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    apiSettings: {
+      upsert: jest.fn(),
+    },
+  },
+}));
+jest.mock("@/lib/logger");
+
+// Import route handlers after mocking
+import { GET, PATCH } from "../route";
+
+const mockAuthenticateRequest = authenticateRequest as unknown as jest.Mock;
+const mockPrisma = prisma as unknown as Record<string, Record<string, jest.Mock>>;
+
+describe("GET /api/api-settings", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns enabled flag", async () => {
+    mockAuthenticateRequest.mockResolvedValue({ userId: "u1" });
+    mockPrisma.apiSettings.upsert.mockResolvedValue({ enabled: true });
+
+    const request = { headers: new Headers() } as unknown as NextRequest;
+    const res = (await GET(request)) as NextResponse;
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.enabled).toBe(true);
+  });
+
+  it("upserts default false when no row exists", async () => {
+    mockAuthenticateRequest.mockResolvedValue({ userId: "u1" });
+    mockPrisma.apiSettings.upsert.mockResolvedValue({ enabled: false });
+
+    const request = { headers: new Headers() } as unknown as NextRequest;
+    await GET(request);
+
+    const upsertCall = mockPrisma.apiSettings.upsert.mock.calls[0];
+    expect(upsertCall[0].where).toEqual({ userId: "u1" });
+    expect(upsertCall[0].create).toEqual({ userId: "u1", enabled: false });
+  });
+
+  it("returns 401 if not authenticated", async () => {
+    mockAuthenticateRequest.mockResolvedValue({
+      response: { status: 401, json: async () => ({ error: "Unauthorized" }) },
+    });
+
+    const request = { headers: new Headers() } as unknown as NextRequest;
+    const res = (await GET(request)) as NextResponse;
+
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("PATCH /api/api-settings", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("updates enabled flag", async () => {
+    mockAuthenticateRequest.mockResolvedValue({ userId: "u1" });
+    mockPrisma.apiSettings.upsert.mockResolvedValue({ enabled: true });
+
+    const request = {
+      headers: new Headers({ "content-type": "application/json" }),
+      json: async () => ({ enabled: true }),
+    } as unknown as NextRequest;
+
+    const res = (await PATCH(request)) as NextResponse;
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.enabled).toBe(true);
+  });
+
+  it("upserts with update and create", async () => {
+    mockAuthenticateRequest.mockResolvedValue({ userId: "u1" });
+    mockPrisma.apiSettings.upsert.mockResolvedValue({ enabled: true });
+
+    const request = {
+      headers: new Headers({ "content-type": "application/json" }),
+      json: async () => ({ enabled: true }),
+    } as unknown as NextRequest;
+
+    await PATCH(request);
+
+    const upsertCall = mockPrisma.apiSettings.upsert.mock.calls[0];
+    expect(upsertCall[0].where).toEqual({ userId: "u1" });
+    expect(upsertCall[0].update).toEqual({ enabled: true });
+    expect(upsertCall[0].create).toEqual({ userId: "u1", enabled: true });
+  });
+
+  it("rejects non-boolean enabled value", async () => {
+    mockAuthenticateRequest.mockResolvedValue({ userId: "u1" });
+
+    const request = {
+      headers: new Headers({ "content-type": "application/json" }),
+      json: async () => ({ enabled: "yes" }),
+    } as unknown as NextRequest;
+
+    const res = (await PATCH(request)) as NextResponse;
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("boolean");
+  });
+
+  it("returns 401 if not authenticated", async () => {
+    mockAuthenticateRequest.mockResolvedValue({
+      response: { status: 401, json: async () => ({ error: "Unauthorized" }) },
+    });
+
+    const request = {
+      headers: new Headers({ "content-type": "application/json" }),
+      json: async () => ({ enabled: true }),
+    } as unknown as NextRequest;
+
+    const res = (await PATCH(request)) as NextResponse;
+
+    expect(res.status).toBe(401);
+  });
+
+  it("disables API access when enabled is set to false", async () => {
+    mockAuthenticateRequest.mockResolvedValue({ userId: "u1" });
+    mockPrisma.apiSettings.upsert.mockResolvedValue({ enabled: false });
+
+    const request = {
+      headers: new Headers({ "content-type": "application/json" }),
+      json: async () => ({ enabled: false }),
+    } as unknown as NextRequest;
+
+    const res = (await PATCH(request)) as NextResponse;
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.enabled).toBe(false);
+
+    const upsertCall = mockPrisma.apiSettings.upsert.mock.calls[0];
+    expect(upsertCall[0].update).toEqual({ enabled: false });
+  });
+});

--- a/src/app/api/api-settings/route.ts
+++ b/src/app/api/api-settings/route.ts
@@ -1,0 +1,110 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { authenticateRequest } from "@/lib/auth/api-auth";
+import { logger } from "@/lib/logger";
+import { prisma } from "@/lib/prisma";
+
+const LOG_SOURCE = "ApiSettingsRoute";
+
+/**
+ * GET /api/api-settings — Get the user's API settings (the enable gate).
+ *
+ * Returns { enabled: boolean }.
+ * If no row exists, treats as false (optionally upserts a default).
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const auth = await authenticateRequest(request, LOG_SOURCE);
+    if ("response" in auth) {
+      return auth.response;
+    }
+
+    const userId = auth.userId;
+
+    // Upsert default false, matching the auto-schedule-settings pattern
+    const settings = await prisma.apiSettings.upsert({
+      where: { userId },
+      update: {},
+      create: {
+        userId,
+        enabled: false,
+      },
+      select: {
+        enabled: true,
+      },
+    });
+
+    return NextResponse.json({
+      enabled: settings.enabled,
+    });
+  } catch (error) {
+    logger.error(
+      "Failed to fetch API settings",
+      { error: error instanceof Error ? error.message : "Unknown error" },
+      LOG_SOURCE
+    );
+    return NextResponse.json(
+      { error: "Failed to fetch API settings" },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * PATCH /api/api-settings — Update the user's API settings.
+ *
+ * Body: { enabled: boolean }
+ * Upserts with the userId as the key.
+ * Returns { enabled }.
+ */
+export async function PATCH(request: NextRequest) {
+  try {
+    const auth = await authenticateRequest(request, LOG_SOURCE);
+    if ("response" in auth) {
+      return auth.response;
+    }
+
+    const userId = auth.userId;
+    const body = await request.json();
+    const { enabled } = body;
+
+    if (typeof enabled !== "boolean") {
+      return NextResponse.json(
+        { error: "enabled must be a boolean" },
+        { status: 400 }
+      );
+    }
+
+    const settings = await prisma.apiSettings.upsert({
+      where: { userId },
+      update: { enabled },
+      create: {
+        userId,
+        enabled,
+      },
+      select: {
+        enabled: true,
+      },
+    });
+
+    logger.info(
+      "Updated API settings",
+      { userId, enabled: settings.enabled },
+      LOG_SOURCE
+    );
+
+    return NextResponse.json({
+      enabled: settings.enabled,
+    });
+  } catch (error) {
+    logger.error(
+      "Failed to update API settings",
+      { error: error instanceof Error ? error.message : "Unknown error" },
+      LOG_SOURCE
+    );
+    return NextResponse.json(
+      { error: "Failed to update API settings" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/v1/events/[id]/route.ts
+++ b/src/app/api/v1/events/[id]/route.ts
@@ -4,6 +4,7 @@ import { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { logger } from "@/lib/logger";
 import { ApiHttpError, v1Write, v1Read } from "@/lib/api/v1";
+import { parseApiDate } from "@/lib/api/dates";
 
 const LOG_SOURCE = "v1-events-id-route";
 
@@ -89,30 +90,14 @@ async function updateEvent(
     throw new ApiHttpError("INVALID_ARGUMENT", "Body must be a JSON object");
   }
 
-  // Validate if start/end are being updated
+  // Validate if start/end are being updated (strict RFC 3339)
   if (updates.start || updates.end) {
     const startTime = updates.start
-      ? new Date(updates.start).getTime()
+      ? parseApiDate(updates.start, "start").getTime()
       : event.start.getTime();
     const endTime = updates.end
-      ? new Date(updates.end).getTime()
+      ? parseApiDate(updates.end, "end").getTime()
       : event.end.getTime();
-
-    if (isNaN(startTime)) {
-      throw new ApiHttpError(
-        "INVALID_ARGUMENT",
-        "start must be a valid ISO date",
-        { field: "start" }
-      );
-    }
-
-    if (isNaN(endTime)) {
-      throw new ApiHttpError(
-        "INVALID_ARGUMENT",
-        "end must be a valid ISO date",
-        { field: "end" }
-      );
-    }
 
     if (endTime <= startTime) {
       throw new ApiHttpError(
@@ -141,8 +126,8 @@ async function updateEvent(
   if ("allDay" in updates) data.allDay = updates.allDay;
   if ("isRecurring" in updates) data.isRecurring = updates.isRecurring;
   if ("recurrenceRule" in updates) data.recurrenceRule = updates.recurrenceRule;
-  if ("start" in updates) data.start = new Date(String(updates.start));
-  if ("end" in updates) data.end = new Date(String(updates.end));
+  if ("start" in updates) data.start = parseApiDate(updates.start, "start");
+  if ("end" in updates) data.end = parseApiDate(updates.end, "end");
 
   const updated = await prisma.calendarEvent.update({
     where: { id: eventId },

--- a/src/app/api/v1/events/[id]/route.ts
+++ b/src/app/api/v1/events/[id]/route.ts
@@ -1,0 +1,172 @@
+import { NextRequest } from "next/server";
+import { Prisma } from "@prisma/client";
+
+import { prisma } from "@/lib/prisma";
+import { logger } from "@/lib/logger";
+import { ApiHttpError, v1Write, v1Read } from "@/lib/api/v1";
+
+const LOG_SOURCE = "v1-events-id-route";
+
+/**
+ * GET /api/v1/events/[id] — get a single event
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  return v1Read(request, async ({ userId }) => {
+    const { id } = await params;
+    return getEvent(userId, id);
+  });
+}
+
+/**
+ * PATCH /api/v1/events/[id] — update a single event
+ */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  return v1Write(request, "PATCH /api/v1/events/[id]", async ({ userId }) => {
+    const { id } = await params;
+    return updateEvent(userId, id, request);
+  });
+}
+
+/**
+ * DELETE /api/v1/events/[id] — delete a single event
+ */
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  return v1Write(
+    request,
+    "DELETE /api/v1/events/[id]",
+    async ({ userId }) => {
+      const { id } = await params;
+      return deleteEvent(userId, id);
+    }
+  );
+}
+
+async function getEvent(userId: string, eventId: string) {
+  // Fetch event and check ownership via feed.userId
+  const event = await prisma.calendarEvent.findUnique({
+    where: { id: eventId },
+    include: { feed: true },
+  });
+
+  if (!event || event.feed.userId !== userId) {
+    throw new ApiHttpError("NOT_FOUND", "Event not found");
+  }
+
+  logger.debug(`Retrieved event ${eventId} for user ${userId}`, {}, LOG_SOURCE);
+
+  return {
+    status: 200,
+    body: event,
+  };
+}
+
+async function updateEvent(
+  userId: string,
+  eventId: string,
+  request: NextRequest
+) {
+  // Check ownership first
+  const event = await prisma.calendarEvent.findUnique({
+    where: { id: eventId },
+    include: { feed: true },
+  });
+
+  if (!event || event.feed.userId !== userId) {
+    throw new ApiHttpError("NOT_FOUND", "Event not found");
+  }
+
+  const updates = await request.json();
+
+  // Validate if start/end are being updated
+  if (updates.start || updates.end) {
+    const startTime = updates.start
+      ? new Date(updates.start).getTime()
+      : event.start.getTime();
+    const endTime = updates.end
+      ? new Date(updates.end).getTime()
+      : event.end.getTime();
+
+    if (isNaN(startTime)) {
+      throw new ApiHttpError(
+        "INVALID_ARGUMENT",
+        "start must be a valid ISO date",
+        { field: "start" }
+      );
+    }
+
+    if (isNaN(endTime)) {
+      throw new ApiHttpError(
+        "INVALID_ARGUMENT",
+        "end must be a valid ISO date",
+        { field: "end" }
+      );
+    }
+
+    if (endTime <= startTime) {
+      throw new ApiHttpError(
+        "INVALID_ARGUMENT",
+        "end must be after start",
+        { field: "end" }
+      );
+    }
+  }
+
+  // Validate title if present
+  if (updates.title !== undefined && !updates.title) {
+    throw new ApiHttpError(
+      "INVALID_ARGUMENT",
+      "title cannot be empty",
+      { field: "title" }
+    );
+  }
+
+  // Transform date strings to Date objects
+  const data: Prisma.CalendarEventUpdateInput = { ...updates };
+  if (data.start) data.start = new Date(String(data.start));
+  if (data.end) data.end = new Date(String(data.end));
+
+  const updated = await prisma.calendarEvent.update({
+    where: { id: eventId },
+    data,
+    include: { feed: true },
+  });
+
+  logger.info(`Updated event ${eventId} for user ${userId}`, {}, LOG_SOURCE);
+
+  return {
+    status: 200,
+    body: updated,
+  };
+}
+
+async function deleteEvent(userId: string, eventId: string) {
+  // Check ownership first
+  const event = await prisma.calendarEvent.findUnique({
+    where: { id: eventId },
+    include: { feed: true },
+  });
+
+  if (!event || event.feed.userId !== userId) {
+    throw new ApiHttpError("NOT_FOUND", "Event not found");
+  }
+
+  await prisma.calendarEvent.delete({
+    where: { id: eventId },
+  });
+
+  logger.info(`Deleted event ${eventId} for user ${userId}`, {}, LOG_SOURCE);
+
+  return {
+    status: 200,
+    body: { deleted: true, id: eventId },
+  };
+}

--- a/src/app/api/v1/events/[id]/route.ts
+++ b/src/app/api/v1/events/[id]/route.ts
@@ -85,6 +85,9 @@ async function updateEvent(
   }
 
   const updates = await request.json();
+  if (!updates || typeof updates !== "object" || Array.isArray(updates)) {
+    throw new ApiHttpError("INVALID_ARGUMENT", "Body must be a JSON object");
+  }
 
   // Validate if start/end are being updated
   if (updates.start || updates.end) {
@@ -129,10 +132,17 @@ async function updateEvent(
     );
   }
 
-  // Transform date strings to Date objects
-  const data: Prisma.CalendarEventUpdateInput = { ...updates };
-  if (data.start) data.start = new Date(String(data.start));
-  if (data.end) data.end = new Date(String(data.end));
+  // Explicit allow-list — never let the caller move the event to another feed
+  // (feedId) or touch sync/recurrence-internal columns (masterEventId, etc.).
+  const data: Prisma.CalendarEventUpdateInput = {};
+  if ("title" in updates) data.title = updates.title;
+  if ("description" in updates) data.description = updates.description;
+  if ("location" in updates) data.location = updates.location;
+  if ("allDay" in updates) data.allDay = updates.allDay;
+  if ("isRecurring" in updates) data.isRecurring = updates.isRecurring;
+  if ("recurrenceRule" in updates) data.recurrenceRule = updates.recurrenceRule;
+  if ("start" in updates) data.start = new Date(String(updates.start));
+  if ("end" in updates) data.end = new Date(String(updates.end));
 
   const updated = await prisma.calendarEvent.update({
     where: { id: eventId },

--- a/src/app/api/v1/events/__tests__/route.test.ts
+++ b/src/app/api/v1/events/__tests__/route.test.ts
@@ -359,13 +359,11 @@ describe("GET /api/v1/events — list events", () => {
 
     await getHandler(request);
 
-    expect(mockEvent.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: {
-          feed: { userId: "u1" },
-        },
-      })
-    );
+    // Scoped to the user's feeds, and always bounded to the query window.
+    const where = mockEvent.findMany.mock.calls[0][0].where;
+    expect(where.feed).toEqual({ userId: "u1" });
+    expect(where.start.gte).toBeInstanceOf(Date);
+    expect(where.start.lte).toBeInstanceOf(Date);
   });
 
   it("rejects invalid date formats", async () => {
@@ -469,6 +467,27 @@ describe("PATCH /api/v1/events/[id]", () => {
       data: { title: "New Title" },
       include: { feed: true },
     });
+  });
+
+  it("ignores injected feedId (cannot move an event to another feed)", async () => {
+    mockEvent.findUnique.mockResolvedValue({
+      id: "evt1",
+      feedId: "feed1",
+      start: new Date("2026-06-22T10:00:00Z"),
+      end: new Date("2026-06-22T11:00:00Z"),
+      feed: { userId: "u1" },
+    });
+    mockEvent.update.mockResolvedValue({ id: "evt1", title: "x" });
+
+    await PATCH(
+      req({ title: "x", feedId: "victim-feed", isMaster: true }),
+      { params: Promise.resolve({ id: "evt1" }) }
+    );
+
+    const data = mockEvent.update.mock.calls[0][0].data;
+    expect(data.feedId).toBeUndefined();
+    expect(data.isMaster).toBeUndefined();
+    expect(data.title).toBe("x");
   });
 
   it("returns 404 for an event not owned by the user", async () => {

--- a/src/app/api/v1/events/__tests__/route.test.ts
+++ b/src/app/api/v1/events/__tests__/route.test.ts
@@ -1,0 +1,568 @@
+import { NextRequest } from "next/server";
+import { POST as postHandler, GET as getHandler } from "../route";
+import { GET, PATCH, DELETE } from "../[id]/route";
+
+import { requireV1Auth } from "@/lib/auth/api-key";
+import { runIdempotent } from "@/lib/api/idempotency";
+import { prisma } from "@/lib/prisma";
+import { _resetRateLimitBuckets } from "@/lib/api/rate-limit";
+
+jest.mock("@/lib/auth/api-key", () => ({ requireV1Auth: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    calendarFeed: {
+      findFirst: jest.fn(),
+      create: jest.fn(),
+    },
+    calendarEvent: {
+      create: jest.fn(),
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    },
+  },
+}));
+jest.mock("@/lib/logger", () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+jest.mock("@/lib/api/idempotency", () => ({
+  runIdempotent: jest.fn(({ produce }) => produce()),
+}));
+
+const mockAuth = requireV1Auth as unknown as jest.Mock;
+const mockIdem = runIdempotent as unknown as jest.Mock;
+const mockFeed = prisma.calendarFeed as unknown as {
+  findFirst: jest.Mock;
+  create: jest.Mock;
+};
+const mockEvent = prisma.calendarEvent as unknown as {
+  create: jest.Mock;
+  findMany: jest.Mock;
+  findUnique: jest.Mock;
+  update: jest.Mock;
+  delete: jest.Mock;
+};
+
+function req(
+  body?: unknown,
+  headers: Record<string, string> = {}
+): NextRequest {
+  const request = { headers: new Headers(headers) } as unknown as NextRequest;
+  if (body) {
+    request.json = jest.fn(async () => body);
+  }
+  return request;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  _resetRateLimitBuckets();
+  mockIdem.mockImplementation(({ produce }) => produce());
+  mockAuth.mockResolvedValue({ userId: "u1", authMethod: "api_key" });
+});
+
+describe("POST /api/v1/events — create events", () => {
+  it("auto-resolves an existing LOCAL feed and creates a single event", async () => {
+    const existingFeed = { id: "feed1", name: "Local Calendar", type: "LOCAL" };
+    const createdEvent = {
+      id: "evt1",
+      feedId: "feed1",
+      title: "Meeting",
+      start: new Date("2026-06-22T10:00:00Z"),
+      end: new Date("2026-06-22T11:00:00Z"),
+      description: null,
+      location: null,
+      isRecurring: false,
+      recurrenceRule: null,
+      allDay: false,
+    };
+
+    mockFeed.findFirst.mockResolvedValue(existingFeed);
+    mockEvent.create.mockResolvedValue(createdEvent);
+
+    const res = await postHandler(
+      req(
+        {
+          title: "Meeting",
+          start: "2026-06-22T10:00:00Z",
+          end: "2026-06-22T11:00:00Z",
+        }
+      )
+    );
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.id).toBe("evt1");
+    expect(body.title).toBe("Meeting");
+
+    // Verify feed lookup was scoped to userId
+    expect(mockFeed.findFirst).toHaveBeenCalledWith({
+      where: { userId: "u1", type: "LOCAL" },
+    });
+    // Verify event was created on the feed
+    expect(mockEvent.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          feedId: "feed1",
+          title: "Meeting",
+        }),
+      })
+    );
+  });
+
+  it("creates a LOCAL feed when none exists for the user", async () => {
+    const newFeed = {
+      id: "feed2",
+      name: "Local Calendar",
+      type: "LOCAL",
+      userId: "u1",
+      enabled: true,
+    };
+    const createdEvent = {
+      id: "evt2",
+      feedId: "feed2",
+      title: "Standup",
+      start: new Date("2026-06-22T09:00:00Z"),
+      end: new Date("2026-06-22T09:15:00Z"),
+      description: null,
+      location: null,
+      isRecurring: false,
+      recurrenceRule: null,
+      allDay: false,
+    };
+
+    mockFeed.findFirst.mockResolvedValue(null);
+    mockFeed.create.mockResolvedValue(newFeed);
+    mockEvent.create.mockResolvedValue(createdEvent);
+
+    const res = await postHandler(
+      req({
+        title: "Standup",
+        start: "2026-06-22T09:00:00Z",
+        end: "2026-06-22T09:15:00Z",
+      })
+    );
+
+    expect(res.status).toBe(201);
+
+    // Verify feed creation with correct structure
+    expect(mockFeed.create).toHaveBeenCalledWith({
+      data: {
+        name: "Local Calendar",
+        type: "LOCAL",
+        userId: "u1",
+        enabled: true,
+      },
+    });
+  });
+
+  it("creates multiple events in a batch", async () => {
+    const existingFeed = { id: "feed1", type: "LOCAL" };
+    const events = [
+      {
+        id: "evt1",
+        feedId: "feed1",
+        title: "Event 1",
+        start: new Date("2026-06-22T10:00:00Z"),
+        end: new Date("2026-06-22T11:00:00Z"),
+        description: null,
+        location: null,
+        isRecurring: false,
+        recurrenceRule: null,
+        allDay: false,
+      },
+      {
+        id: "evt2",
+        feedId: "feed1",
+        title: "Event 2",
+        start: new Date("2026-06-22T14:00:00Z"),
+        end: new Date("2026-06-22T15:00:00Z"),
+        description: null,
+        location: null,
+        isRecurring: false,
+        recurrenceRule: null,
+        allDay: false,
+      },
+    ];
+
+    mockFeed.findFirst.mockResolvedValue(existingFeed);
+    mockEvent.create
+      .mockResolvedValueOnce(events[0])
+      .mockResolvedValueOnce(events[1]);
+
+    const res = await postHandler(
+      req([
+        {
+          title: "Event 1",
+          start: "2026-06-22T10:00:00Z",
+          end: "2026-06-22T11:00:00Z",
+        },
+        {
+          title: "Event 2",
+          start: "2026-06-22T14:00:00Z",
+          end: "2026-06-22T15:00:00Z",
+        },
+      ])
+    );
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(Array.isArray(body)).toBe(true);
+    expect(body.length).toBe(2);
+    expect(mockEvent.create).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects when end <= start", async () => {
+    mockFeed.findFirst.mockResolvedValue({ id: "feed1" });
+
+    const res = await postHandler(
+      req({
+        title: "Bad Event",
+        start: "2026-06-22T11:00:00Z",
+        end: "2026-06-22T10:00:00Z",
+      })
+    );
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe("INVALID_ARGUMENT");
+    expect(body.error.field).toBe("end");
+    expect(mockEvent.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects when title is missing", async () => {
+    mockFeed.findFirst.mockResolvedValue({ id: "feed1" });
+
+    const res = await postHandler(
+      req({
+        start: "2026-06-22T10:00:00Z",
+        end: "2026-06-22T11:00:00Z",
+      })
+    );
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe("INVALID_ARGUMENT");
+    expect(body.error.field).toBe("title");
+  });
+
+  it("rejects batch size > 100", async () => {
+    const events = Array.from({ length: 101 }, (_, i) => ({
+      title: `Event ${i}`,
+      start: "2026-06-22T10:00:00Z",
+      end: "2026-06-22T11:00:00Z",
+    }));
+
+    const res = await postHandler(req(events));
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe("INVALID_ARGUMENT");
+    expect(mockEvent.create).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/v1/events — list events", () => {
+  it("returns paginated events for the user filtered by date range", async () => {
+    const events = [
+      {
+        id: "evt1",
+        feedId: "feed1",
+        title: "Event 1",
+        start: new Date("2026-06-22T10:00:00Z"),
+        end: new Date("2026-06-22T11:00:00Z"),
+      },
+      {
+        id: "evt2",
+        feedId: "feed1",
+        title: "Event 2",
+        start: new Date("2026-06-23T10:00:00Z"),
+        end: new Date("2026-06-23T11:00:00Z"),
+      },
+    ];
+
+    mockEvent.findMany.mockResolvedValue(events);
+
+    const request = {
+      url: "http://localhost/api/v1/events?from=2026-06-22&to=2026-06-23&limit=50",
+      headers: new Headers(),
+    } as unknown as NextRequest;
+
+    const res = await getHandler(request);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toHaveLength(2);
+    expect(body.has_more).toBe(false);
+    expect(body.next_cursor).toBeNull();
+
+    // Verify query scoped to userId + date range
+    expect(mockEvent.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          feed: { userId: "u1" },
+          start: expect.objectContaining({
+            gte: expect.any(Date),
+            lte: expect.any(Date),
+          }),
+        },
+      })
+    );
+  });
+
+  it("respects cursor pagination", async () => {
+    const events = [
+      {
+        id: "evt2",
+        start: new Date("2026-06-23T10:00:00Z"),
+      },
+      {
+        id: "evt3",
+        start: new Date("2026-06-24T10:00:00Z"),
+      },
+    ];
+
+    mockEvent.findMany.mockResolvedValue(events);
+
+    const cursorStartIso = "2026-06-22T10:00:00.000Z";
+    const cursor = `${cursorStartIso}|evt1`;
+    const request = {
+      url: `http://localhost/api/v1/events?cursor=${encodeURIComponent(cursor)}&limit=2`,
+      headers: new Headers(),
+    } as unknown as NextRequest;
+
+    const res = await getHandler(request);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toHaveLength(2);
+
+    // Verify cursor was decoded and used in WHERE clause
+    expect(mockEvent.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          feed: { userId: "u1" },
+          OR: expect.any(Array),
+        }),
+      })
+    );
+  });
+
+  it("filters events by userId via feed relation", async () => {
+    mockEvent.findMany.mockResolvedValue([]);
+
+    const request = {
+      url: "http://localhost/api/v1/events",
+      headers: new Headers(),
+    } as unknown as NextRequest;
+
+    await getHandler(request);
+
+    expect(mockEvent.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          feed: { userId: "u1" },
+        },
+      })
+    );
+  });
+
+  it("rejects invalid date formats", async () => {
+    const request = {
+      url: "http://localhost/api/v1/events?from=not-a-date",
+      headers: new Headers(),
+    } as unknown as NextRequest;
+
+    const res = await getHandler(request);
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe("INVALID_ARGUMENT");
+    expect(body.error.field).toBe("from");
+  });
+});
+
+describe("GET /api/v1/events/[id]", () => {
+  it("returns an event owned by the user", async () => {
+    const event = {
+      id: "evt1",
+      feedId: "feed1",
+      title: "My Event",
+      feed: { userId: "u1" },
+    };
+
+    mockEvent.findUnique.mockResolvedValue(event);
+
+    const res = await GET(
+      req(),
+      { params: Promise.resolve({ id: "evt1" }) }
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.id).toBe("evt1");
+  });
+
+  it("returns 404 for an event owned by another user", async () => {
+    const event = {
+      id: "evt1",
+      feedId: "feed1",
+      title: "Someone Else's Event",
+      feed: { userId: "u2" }, // Different owner
+    };
+
+    mockEvent.findUnique.mockResolvedValue(event);
+
+    const res = await GET(
+      req(),
+      { params: Promise.resolve({ id: "evt1" }) }
+    );
+
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns 404 for a non-existent event", async () => {
+    mockEvent.findUnique.mockResolvedValue(null);
+
+    const res = await GET(
+      req(),
+      { params: Promise.resolve({ id: "evt-notfound" }) }
+    );
+
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("PATCH /api/v1/events/[id]", () => {
+  it("updates an event owned by the user", async () => {
+    const existingEvent = {
+      id: "evt1",
+      feedId: "feed1",
+      title: "Old Title",
+      start: new Date("2026-06-22T10:00:00Z"),
+      end: new Date("2026-06-22T11:00:00Z"),
+      feed: { userId: "u1" },
+    };
+
+    const updatedEvent = {
+      ...existingEvent,
+      title: "New Title",
+    };
+
+    mockEvent.findUnique.mockResolvedValue(existingEvent);
+    mockEvent.update.mockResolvedValue(updatedEvent);
+
+    const res = await PATCH(
+      req({ title: "New Title" }),
+      { params: Promise.resolve({ id: "evt1" }) }
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.title).toBe("New Title");
+
+    expect(mockEvent.update).toHaveBeenCalledWith({
+      where: { id: "evt1" },
+      data: { title: "New Title" },
+      include: { feed: true },
+    });
+  });
+
+  it("returns 404 for an event not owned by the user", async () => {
+    const event = {
+      id: "evt1",
+      feed: { userId: "u2" },
+    };
+
+    mockEvent.findUnique.mockResolvedValue(event);
+
+    const res = await PATCH(
+      req({ title: "Attempted Update" }),
+      { params: Promise.resolve({ id: "evt1" }) }
+    );
+
+    expect(res.status).toBe(404);
+    expect(mockEvent.update).not.toHaveBeenCalled();
+  });
+
+  it("validates end > start on update", async () => {
+    const existingEvent = {
+      id: "evt1",
+      feedId: "feed1",
+      title: "Event",
+      start: new Date("2026-06-22T10:00:00Z"),
+      end: new Date("2026-06-22T11:00:00Z"),
+      feed: { userId: "u1" },
+    };
+
+    mockEvent.findUnique.mockResolvedValue(existingEvent);
+
+    const res = await PATCH(
+      req({ end: "2026-06-22T09:00:00Z" }),
+      { params: Promise.resolve({ id: "evt1" }) }
+    );
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.field).toBe("end");
+    expect(mockEvent.update).not.toHaveBeenCalled();
+  });
+});
+
+describe("DELETE /api/v1/events/[id]", () => {
+  it("deletes an event owned by the user", async () => {
+    const event = {
+      id: "evt1",
+      feedId: "feed1",
+      feed: { userId: "u1" },
+    };
+
+    mockEvent.findUnique.mockResolvedValue(event);
+    mockEvent.delete.mockResolvedValue(event);
+
+    const res = await DELETE(
+      req(),
+      { params: Promise.resolve({ id: "evt1" }) }
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.deleted).toBe(true);
+    expect(body.id).toBe("evt1");
+
+    expect(mockEvent.delete).toHaveBeenCalledWith({
+      where: { id: "evt1" },
+    });
+  });
+
+  it("returns 404 for an event not owned by the user", async () => {
+    const event = {
+      id: "evt1",
+      feed: { userId: "u2" },
+    };
+
+    mockEvent.findUnique.mockResolvedValue(event);
+
+    const res = await DELETE(
+      req(),
+      { params: Promise.resolve({ id: "evt1" }) }
+    );
+
+    expect(res.status).toBe(404);
+    expect(mockEvent.delete).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 for a non-existent event", async () => {
+    mockEvent.findUnique.mockResolvedValue(null);
+
+    const res = await DELETE(
+      req(),
+      { params: Promise.resolve({ id: "evt-notfound" }) }
+    );
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/src/app/api/v1/events/route.ts
+++ b/src/app/api/v1/events/route.ts
@@ -1,0 +1,295 @@
+import { NextRequest } from "next/server";
+import { Prisma } from "@prisma/client";
+
+import { prisma } from "@/lib/prisma";
+import { logger } from "@/lib/logger";
+import { ApiHttpError, v1Write, v1Read, V1Context } from "@/lib/api/v1";
+import { paginated } from "@/lib/api/respond";
+
+const LOG_SOURCE = "v1-events-route";
+
+/**
+ * POST /api/v1/events — create event(s)
+ *
+ * Auto-resolves the user's writable LOCAL feed (creating if needed).
+ * Accepts a single event object OR array of events (batch cap: 100).
+ * Validates: title, start, end required; end > start.
+ *
+ * Response: single object for single input, array for array. status 201.
+ */
+export async function POST(request: NextRequest) {
+  return v1Write(request, "POST /api/v1/events", createEvents);
+}
+
+async function createEvents({ userId, request }: V1Context) {
+  const body = await request.json();
+
+  // Accept single or array
+  const isArray = Array.isArray(body);
+  const events = isArray ? body : [body];
+
+  if (!Array.isArray(events) || events.length === 0) {
+    throw new ApiHttpError(
+      "INVALID_ARGUMENT",
+      "Request body must be an event object or a non-empty array of events"
+    );
+  }
+
+  if (events.length > 100) {
+    throw new ApiHttpError(
+      "INVALID_ARGUMENT",
+      "Batch size exceeds maximum of 100 events"
+    );
+  }
+
+  // Validate all events first (before any database writes)
+  for (const event of events) {
+    validateEventInput(event);
+  }
+
+  // Auto-resolve LOCAL feed: find existing or create new
+  let feed = await prisma.calendarFeed.findFirst({
+    where: {
+      userId,
+      type: "LOCAL",
+    },
+  });
+
+  if (!feed) {
+    // Create LOCAL feed if none exists
+    feed = await prisma.calendarFeed.create({
+      data: {
+        name: "Local Calendar",
+        type: "LOCAL",
+        userId,
+        enabled: true,
+      },
+    });
+  }
+
+  // Create events
+  const createdEvents = await Promise.all(
+    events.map((evt) =>
+      prisma.calendarEvent.create({
+        data: {
+          feedId: feed!.id,
+          title: evt.title,
+          description: evt.description,
+          start: new Date(evt.start),
+          end: new Date(evt.end),
+          location: evt.location,
+          isRecurring: evt.isRecurring ?? false,
+          recurrenceRule: evt.recurrenceRule,
+          allDay: evt.allDay ?? false,
+        },
+      })
+    )
+  );
+
+  logger.info(
+    `Created ${createdEvents.length} event(s) for user ${userId}`,
+    { feedId: feed.id, eventCount: createdEvents.length },
+    LOG_SOURCE
+  );
+
+  return {
+    status: 201,
+    body: isArray ? createdEvents : createdEvents[0],
+  };
+}
+
+function validateEventInput(event: unknown) {
+  if (!event || typeof event !== "object") {
+    throw new ApiHttpError(
+      "INVALID_ARGUMENT",
+      "Each event must be an object"
+    );
+  }
+
+  const e = event as Record<string, unknown>;
+
+  if (!e.title) {
+    throw new ApiHttpError(
+      "INVALID_ARGUMENT",
+      "title is required",
+      { field: "title" }
+    );
+  }
+
+  if (!e.start) {
+    throw new ApiHttpError(
+      "INVALID_ARGUMENT",
+      "start is required",
+      { field: "start" }
+    );
+  }
+
+  if (!e.end) {
+    throw new ApiHttpError(
+      "INVALID_ARGUMENT",
+      "end is required",
+      { field: "end" }
+    );
+  }
+
+  const startTime = new Date(String(e.start)).getTime();
+  const endTime = new Date(String(e.end)).getTime();
+
+  if (isNaN(startTime)) {
+    throw new ApiHttpError(
+      "INVALID_ARGUMENT",
+      "start must be a valid ISO date",
+      { field: "start" }
+    );
+  }
+
+  if (isNaN(endTime)) {
+    throw new ApiHttpError(
+      "INVALID_ARGUMENT",
+      "end must be a valid ISO date",
+      { field: "end" }
+    );
+  }
+
+  if (endTime <= startTime) {
+    throw new ApiHttpError(
+      "INVALID_ARGUMENT",
+      "end must be after start",
+      { field: "end" }
+    );
+  }
+}
+
+/**
+ * GET /api/v1/events — list events by date range
+ *
+ * Query params:
+ *   - from: ISO date (inclusive)
+ *   - to: ISO date (inclusive)
+ *   - cursor: opaque cursor for pagination
+ *   - limit: page size (default 50, max 500)
+ *
+ * Returns paginated shape: { data, next_cursor, has_more }
+ * Sorted by start, then id (stable pagination).
+ */
+export async function GET(request: NextRequest) {
+  return v1Read(request, listEvents);
+}
+
+async function listEvents({ userId, request }: V1Context) {
+  const url = new URL(request.url);
+  const from = url.searchParams.get("from");
+  const to = url.searchParams.get("to");
+  const cursor = url.searchParams.get("cursor");
+  const limitStr = url.searchParams.get("limit") ?? "50";
+
+  const limit = Math.min(parseInt(limitStr, 10) || 50, 500);
+  if (limit < 1) {
+    throw new ApiHttpError(
+      "INVALID_ARGUMENT",
+      "limit must be at least 1",
+      { field: "limit" }
+    );
+  }
+
+  // Parse and validate date range
+  let fromDate: Date | null = null;
+  let toDate: Date | null = null;
+
+  if (from) {
+    fromDate = new Date(from);
+    if (isNaN(fromDate.getTime())) {
+      throw new ApiHttpError(
+        "INVALID_ARGUMENT",
+        "from must be a valid ISO date",
+        { field: "from" }
+      );
+    }
+  }
+
+  if (to) {
+    toDate = new Date(to);
+    if (isNaN(toDate.getTime())) {
+      throw new ApiHttpError(
+        "INVALID_ARGUMENT",
+        "to must be a valid ISO date",
+        { field: "to" }
+      );
+    }
+  }
+
+  // Decode cursor: format is "{start.toISOString()}|{id}"
+  let cursorStart: Date | null = null;
+  let cursorId: string | null = null;
+
+  if (cursor) {
+    const parts = cursor.split("|");
+    if (parts.length === 2) {
+      const cursorDate = new Date(parts[0]);
+      if (!isNaN(cursorDate.getTime())) {
+        cursorStart = cursorDate;
+        cursorId = parts[1];
+      }
+    }
+  }
+
+  // Build where clause: events owned by this user, filtered by date range
+  const where: Prisma.CalendarEventWhereInput = {
+    feed: {
+      userId,
+    },
+  };
+
+  if (fromDate || toDate) {
+    where.start = {};
+    if (fromDate) where.start.gte = fromDate;
+    if (toDate) {
+      // Inclusive end: set to end of day
+      const eod = new Date(toDate);
+      eod.setUTCHours(23, 59, 59, 999);
+      where.start.lte = eod;
+    }
+  }
+
+  // For cursor-based pagination: fetch limit+1 to determine has_more
+  // Apply cursor filtering in the WHERE clause
+  if (cursorStart && cursorId) {
+    where.OR = [
+      { start: { gt: cursorStart } },
+      {
+        AND: [
+          { start: { equals: cursorStart } },
+          { id: { gt: cursorId } },
+        ],
+      },
+    ];
+  }
+
+  const pageSize = limit + 1;
+
+  const events = await prisma.calendarEvent.findMany({
+    where,
+    orderBy: [{ start: "asc" }, { id: "asc" }],
+    take: pageSize,
+  });
+
+  const hasMore = events.length > limit;
+  const result = events.slice(0, limit);
+
+  let nextCursor: string | null = null;
+  if (hasMore && result.length > 0) {
+    const lastEvent = result[result.length - 1];
+    nextCursor = `${lastEvent.start.toISOString()}|${lastEvent.id}`;
+  }
+
+  logger.debug(
+    `Listed ${result.length} events for user ${userId}`,
+    { from: from || null, to: to || null, limit },
+    LOG_SOURCE
+  );
+
+  return {
+    status: 200,
+    body: paginated(result, nextCursor),
+  };
+}

--- a/src/app/api/v1/events/route.ts
+++ b/src/app/api/v1/events/route.ts
@@ -218,6 +218,23 @@ async function listEvents({ userId, request }: V1Context) {
     }
   }
 
+  // Bound every query to a fixed window so no request can scan full history:
+  // up to 2 years ahead and 1 week back (a generous, timezone-offset-safe
+  // buffer). Applied even when from/to are omitted; a wider request is clamped.
+  const nowMs = Date.now();
+  const minStart = new Date(nowMs - 7 * 24 * 60 * 60 * 1000);
+  const maxStart = new Date(nowMs + 2 * 365 * 24 * 60 * 60 * 1000);
+
+  const rangeStart = fromDate && fromDate > minStart ? fromDate : minStart;
+  let rangeEnd: Date;
+  if (toDate) {
+    rangeEnd = new Date(toDate);
+    rangeEnd.setUTCHours(23, 59, 59, 999); // inclusive end-of-day
+    if (rangeEnd > maxStart) rangeEnd = maxStart;
+  } else {
+    rangeEnd = maxStart;
+  }
+
   // Decode cursor: format is "{start.toISOString()}|{id}"
   let cursorStart: Date | null = null;
   let cursorId: string | null = null;
@@ -240,16 +257,7 @@ async function listEvents({ userId, request }: V1Context) {
     },
   };
 
-  if (fromDate || toDate) {
-    where.start = {};
-    if (fromDate) where.start.gte = fromDate;
-    if (toDate) {
-      // Inclusive end: set to end of day
-      const eod = new Date(toDate);
-      eod.setUTCHours(23, 59, 59, 999);
-      where.start.lte = eod;
-    }
-  }
+  where.start = { gte: rangeStart, lte: rangeEnd };
 
   // For cursor-based pagination: fetch limit+1 to determine has_more
   // Apply cursor filtering in the WHERE clause

--- a/src/app/api/v1/events/route.ts
+++ b/src/app/api/v1/events/route.ts
@@ -4,6 +4,7 @@ import { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { logger } from "@/lib/logger";
 import { ApiHttpError, v1Write, v1Read, V1Context } from "@/lib/api/v1";
+import { parseApiDate, parseOptionalApiDate } from "@/lib/api/dates";
 import { paginated } from "@/lib/api/respond";
 
 const LOG_SOURCE = "v1-events-route";
@@ -75,8 +76,8 @@ async function createEvents({ userId, request }: V1Context) {
           feedId: feed!.id,
           title: evt.title,
           description: evt.description,
-          start: new Date(evt.start),
-          end: new Date(evt.end),
+          start: parseApiDate(evt.start, "start"),
+          end: parseApiDate(evt.end, "end"),
           location: evt.location,
           isRecurring: evt.isRecurring ?? false,
           recurrenceRule: evt.recurrenceRule,
@@ -132,24 +133,8 @@ function validateEventInput(event: unknown) {
     );
   }
 
-  const startTime = new Date(String(e.start)).getTime();
-  const endTime = new Date(String(e.end)).getTime();
-
-  if (isNaN(startTime)) {
-    throw new ApiHttpError(
-      "INVALID_ARGUMENT",
-      "start must be a valid ISO date",
-      { field: "start" }
-    );
-  }
-
-  if (isNaN(endTime)) {
-    throw new ApiHttpError(
-      "INVALID_ARGUMENT",
-      "end must be a valid ISO date",
-      { field: "end" }
-    );
-  }
+  const startTime = parseApiDate(e.start, "start").getTime();
+  const endTime = parseApiDate(e.end, "end").getTime();
 
   if (endTime <= startTime) {
     throw new ApiHttpError(
@@ -192,31 +177,9 @@ async function listEvents({ userId, request }: V1Context) {
     );
   }
 
-  // Parse and validate date range
-  let fromDate: Date | null = null;
-  let toDate: Date | null = null;
-
-  if (from) {
-    fromDate = new Date(from);
-    if (isNaN(fromDate.getTime())) {
-      throw new ApiHttpError(
-        "INVALID_ARGUMENT",
-        "from must be a valid ISO date",
-        { field: "from" }
-      );
-    }
-  }
-
-  if (to) {
-    toDate = new Date(to);
-    if (isNaN(toDate.getTime())) {
-      throw new ApiHttpError(
-        "INVALID_ARGUMENT",
-        "to must be a valid ISO date",
-        { field: "to" }
-      );
-    }
-  }
+  // Parse and validate date range (strict RFC 3339)
+  const fromDate = parseOptionalApiDate(from, "from");
+  const toDate = parseOptionalApiDate(to, "to");
 
   // Bound every query to a fixed window so no request can scan full history:
   // up to 2 years ahead and 1 week back (a generous, timezone-offset-safe

--- a/src/app/api/v1/schedule/__tests__/route.test.ts
+++ b/src/app/api/v1/schedule/__tests__/route.test.ts
@@ -4,6 +4,7 @@ import { v1Write } from "@/lib/api/v1";
 import { autoScheduleReadiness } from "@/lib/api/schedule-guard";
 import { _resetRateLimitBuckets } from "@/lib/api/rate-limit";
 import { scheduleAllTasksForUser } from "@/services/scheduling/TaskSchedulingService";
+import { repushDirtyBlocks } from "@/lib/task-block-push";
 
 // Mock dependencies
 jest.mock("@/lib/api/v1");
@@ -12,6 +13,7 @@ jest.mock("@/lib/auth/api-key");
 jest.mock("@/lib/api/idempotency");
 jest.mock("@/lib/logger");
 jest.mock("@/services/scheduling/TaskSchedulingService");
+jest.mock("@/lib/task-block-push");
 
 // Import the route handler after mocking
 import { POST } from "../route";
@@ -19,6 +21,7 @@ import { POST } from "../route";
 const mockV1Write = v1Write as unknown as jest.Mock;
 const mockAutoScheduleReadiness = autoScheduleReadiness as unknown as jest.Mock;
 const mockScheduleAllTasksForUser = scheduleAllTasksForUser as unknown as jest.Mock;
+const mockRepushDirtyBlocks = repushDirtyBlocks as unknown as jest.Mock;
 
 describe("POST /api/v1/schedule", () => {
   beforeEach(() => {
@@ -74,6 +77,9 @@ describe("POST /api/v1/schedule", () => {
     const response = await POST(request);
 
     expect(response.status).toBe(200);
+    // After scheduling, the newly-positioned blocks must be pushed to the
+    // calendar (same as the in-app schedule-all route).
+    expect(mockRepushDirtyBlocks).toHaveBeenCalledWith("u1");
   });
 
   it("uses the tighter rate limit bucket for this heavy path", async () => {

--- a/src/app/api/v1/schedule/__tests__/route.test.ts
+++ b/src/app/api/v1/schedule/__tests__/route.test.ts
@@ -1,0 +1,93 @@
+import { NextRequest } from "next/server";
+
+import { v1Write } from "@/lib/api/v1";
+import { autoScheduleReadiness } from "@/lib/api/schedule-guard";
+import { _resetRateLimitBuckets } from "@/lib/api/rate-limit";
+import { scheduleAllTasksForUser } from "@/services/scheduling/TaskSchedulingService";
+
+// Mock dependencies
+jest.mock("@/lib/api/v1");
+jest.mock("@/lib/api/schedule-guard");
+jest.mock("@/lib/auth/api-key");
+jest.mock("@/lib/api/idempotency");
+jest.mock("@/lib/logger");
+jest.mock("@/services/scheduling/TaskSchedulingService");
+
+// Import the route handler after mocking
+import { POST } from "../route";
+
+const mockV1Write = v1Write as unknown as jest.Mock;
+const mockAutoScheduleReadiness = autoScheduleReadiness as unknown as jest.Mock;
+const mockScheduleAllTasksForUser = scheduleAllTasksForUser as unknown as jest.Mock;
+
+describe("POST /api/v1/schedule", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    _resetRateLimitBuckets();
+  });
+
+  it("calls v1Write with correct routeLabel and rate limit options", async () => {
+    mockV1Write.mockResolvedValue({ status: 200 });
+    const request = { headers: new Headers() } as unknown as NextRequest;
+
+    await POST(request);
+
+    expect(mockV1Write).toHaveBeenCalledWith(
+      request,
+      "POST /api/v1/schedule",
+      expect.any(Function),
+      { bucket: "schedule", limit: 6, windowMs: 60000 }
+    );
+  });
+
+  it("checks readiness and returns 400 if not ready", async () => {
+    mockAutoScheduleReadiness.mockResolvedValue({
+      ready: false,
+      reason: "Auto-scheduling is not configured",
+    });
+
+    const mockProducer = mockV1Write.mock.calls[0]?.[2];
+    if (mockProducer) {
+      await mockProducer({ userId: "u1" });
+      // This should throw ApiHttpError which v1Write catches
+      expect(mockProducer).toBeDefined();
+    }
+  });
+
+  it("schedules tasks and returns scheduled count on success", async () => {
+    const mockTasks = [
+      { id: "t1", title: "Task 1" },
+      { id: "t2", title: "Task 2" },
+    ];
+
+    mockAutoScheduleReadiness.mockResolvedValue({ ready: true });
+    mockScheduleAllTasksForUser.mockResolvedValue(mockTasks);
+
+    mockV1Write.mockImplementation(
+      async (request, label, producer) => {
+        const result = await producer({ userId: "u1" });
+        return { status: result.status, json: async () => result.body };
+      }
+    );
+
+    const request = { headers: new Headers() } as unknown as NextRequest;
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+  });
+
+  it("uses the tighter rate limit bucket for this heavy path", async () => {
+    mockV1Write.mockResolvedValue({ status: 200 });
+    const request = { headers: new Headers() } as unknown as NextRequest;
+
+    await POST(request);
+
+    // Check that the rate limit options match the spec
+    const callArgs = mockV1Write.mock.calls[0];
+    expect(callArgs[3]).toEqual({
+      bucket: "schedule",
+      limit: 6,
+      windowMs: 60000,
+    });
+  });
+});

--- a/src/app/api/v1/schedule/route.ts
+++ b/src/app/api/v1/schedule/route.ts
@@ -3,6 +3,7 @@ import { NextRequest } from "next/server";
 import { v1Write, ApiHttpError } from "@/lib/api/v1";
 import { autoScheduleReadiness } from "@/lib/api/schedule-guard";
 import { logger } from "@/lib/logger";
+import { repushDirtyBlocks } from "@/lib/task-block-push";
 import { scheduleAllTasksForUser } from "@/services/scheduling/TaskSchedulingService";
 
 const LOG_SOURCE = "api-v1-schedule-route";
@@ -27,6 +28,9 @@ export async function POST(request: NextRequest) {
 
       // Schedule all tasks for the user
       const tasks = await scheduleAllTasksForUser(userId);
+
+      // Push newly-scheduled blocks to the calendar (if push is enabled).
+      await repushDirtyBlocks(userId);
 
       logger.info(
         "Scheduled all tasks for user via API",

--- a/src/app/api/v1/schedule/route.ts
+++ b/src/app/api/v1/schedule/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest } from "next/server";
+
+import { v1Write, ApiHttpError } from "@/lib/api/v1";
+import { autoScheduleReadiness } from "@/lib/api/schedule-guard";
+import { logger } from "@/lib/logger";
+import { scheduleAllTasksForUser } from "@/services/scheduling/TaskSchedulingService";
+
+const LOG_SOURCE = "api-v1-schedule-route";
+
+/**
+ * POST /api/v1/schedule — Trigger a replan.
+ *
+ * Checks autoScheduleReadiness first; if not ready, returns 400 with reason.
+ * Otherwise schedules all auto-scheduled tasks for the user.
+ * Uses a tighter rate limit (6/min) since this is a heavy operation.
+ */
+export async function POST(request: NextRequest) {
+  return v1Write(
+    request,
+    "POST /api/v1/schedule",
+    async ({ userId }) => {
+      // Check if the user is ready for auto-scheduling
+      const readiness = await autoScheduleReadiness(userId);
+      if (!readiness.ready) {
+        throw new ApiHttpError("INVALID_ARGUMENT", readiness.reason);
+      }
+
+      // Schedule all tasks for the user
+      const tasks = await scheduleAllTasksForUser(userId);
+
+      logger.info(
+        "Scheduled all tasks for user via API",
+        { userId, scheduledCount: tasks.length },
+        LOG_SOURCE
+      );
+
+      return {
+        status: 200,
+        body: {
+          scheduled: tasks.length,
+          tasks,
+        },
+      };
+    },
+    { bucket: "schedule", limit: 6, windowMs: 60000 }
+  );
+}

--- a/src/app/api/v1/tasks/[id]/route.ts
+++ b/src/app/api/v1/tasks/[id]/route.ts
@@ -1,0 +1,160 @@
+import { NextRequest } from "next/server";
+
+import { v1Read, v1Write, ApiHttpError } from "@/lib/api/v1";
+import { prisma } from "@/lib/prisma";
+import { deleteTaskBlockEvent, schedulePushTaskBlock } from "@/lib/task-block-push";
+import { normalizeRecurrenceRule } from "@/lib/utils/normalize-recurrence-rules";
+
+/**
+ * GET /api/v1/tasks/[id] — Retrieve a single task.
+ *
+ * Returns NOT_FOUND if the task doesn't exist or doesn't belong to the user.
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  return v1Read(request, async ({ userId }) => {
+    const { id } = await params;
+
+    const task = await prisma.task.findFirst({
+      where: {
+        id,
+        userId,
+      },
+      include: {
+        tags: true,
+        project: true,
+      },
+    });
+
+    if (!task) {
+      throw new ApiHttpError("NOT_FOUND", `Task with id ${id} not found`);
+    }
+
+    return {
+      status: 200,
+      body: task,
+    };
+  });
+}
+
+/**
+ * PATCH /api/v1/tasks/[id] — Update a task (partial fields only).
+ *
+ * Returns NOT_FOUND if the task doesn't exist or doesn't belong to the user.
+ * Only provided fields are updated.
+ */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  return v1Write(request, "PATCH /api/v1/tasks/[id]", async ({ userId }) => {
+    const { id } = await params;
+
+    // Verify task exists and belongs to user
+    const existing = await prisma.task.findFirst({
+      where: {
+        id,
+        userId,
+      },
+    });
+
+    if (!existing) {
+      throw new ApiHttpError("NOT_FOUND", `Task with id ${id} not found`);
+    }
+
+    const json = await request.json();
+    const {
+      tagIds,
+      projectId,
+      recurrenceRule,
+      ...updates
+    } = json;
+
+    // Never allow these to be set via PATCH
+    delete updates.userId;
+    delete updates.id;
+    delete updates.createdAt;
+    delete updates.updatedAt;
+
+    // Normalize recurrence rule if provided
+    if (recurrenceRule !== undefined) {
+      updates.recurrenceRule = recurrenceRule
+        ? normalizeRecurrenceRule(recurrenceRule)
+        : null;
+    }
+
+    const updatedTask = await prisma.task.update({
+      where: { id },
+      data: {
+        ...updates,
+        ...(tagIds !== undefined && {
+          tags: {
+            set: [],
+            connect: tagIds.map((tagId: string) => ({ id: tagId })),
+          },
+        }),
+        ...(projectId !== undefined && {
+          projectId: projectId === null ? undefined : projectId,
+        }),
+      },
+      include: {
+        tags: true,
+        project: true,
+      },
+    });
+
+    // Schedule calendar block push for any changes to scheduled times
+    schedulePushTaskBlock(userId, id);
+
+    return {
+      status: 200,
+      body: updatedTask,
+    };
+  });
+}
+
+/**
+ * DELETE /api/v1/tasks/[id] — Delete a task.
+ *
+ * Returns NOT_FOUND if the task doesn't exist or doesn't belong to the user.
+ * Returns 200 with { deleted: true, id }.
+ */
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  return v1Write(request, "DELETE /api/v1/tasks/[id]", async ({ userId }) => {
+    const { id } = await params;
+
+    const task = await prisma.task.findFirst({
+      where: {
+        id,
+        userId,
+      },
+      include: {
+        project: true,
+      },
+    });
+
+    if (!task) {
+      throw new ApiHttpError("NOT_FOUND", `Task with id ${id} not found`);
+    }
+
+    // Delete calendar event if it exists
+    if (task.blockEventId && task.blockFeedId) {
+      await deleteTaskBlockEvent(userId, task.blockEventId, task.blockFeedId);
+    }
+
+    // Delete the task
+    await prisma.task.delete({
+      where: { id },
+    });
+
+    return {
+      status: 200,
+      body: { deleted: true, id },
+    };
+  });
+}

--- a/src/app/api/v1/tasks/[id]/route.ts
+++ b/src/app/api/v1/tasks/[id]/route.ts
@@ -1,3 +1,4 @@
+import { Prisma } from "@prisma/client";
 import { NextRequest } from "next/server";
 
 import { v1Read, v1Write, ApiHttpError } from "@/lib/api/v1";
@@ -65,18 +66,29 @@ export async function PATCH(
     }
 
     const json = await request.json();
-    const {
-      tagIds,
-      projectId,
-      recurrenceRule,
-      ...updates
-    } = json;
+    if (!json || typeof json !== "object" || Array.isArray(json)) {
+      throw new ApiHttpError("INVALID_ARGUMENT", "Body must be a JSON object");
+    }
 
-    // Never allow these to be set via PATCH
-    delete updates.userId;
-    delete updates.id;
-    delete updates.createdAt;
-    delete updates.updatedAt;
+    // Explicit allow-list of caller-updatable fields. Server-controlled columns
+    // (userId, id, scheduledStart, blockEventId, syncStatus, …) are never
+    // accepted, preventing mass-assignment via the public API.
+    const updates: Prisma.TaskUncheckedUpdateInput = {};
+    if ("title" in json) updates.title = json.title;
+    if ("description" in json) updates.description = json.description;
+    if ("status" in json) updates.status = json.status;
+    if ("duration" in json) updates.duration = json.duration;
+    if ("priority" in json) updates.priority = json.priority;
+    if ("energyLevel" in json) updates.energyLevel = json.energyLevel;
+    if ("preferredTime" in json) updates.preferredTime = json.preferredTime;
+    if ("dueDate" in json) {
+      updates.dueDate = json.dueDate ? new Date(json.dueDate) : null;
+    }
+    if ("startDate" in json) {
+      updates.startDate = json.startDate ? new Date(json.startDate) : null;
+    }
+
+    const { tagIds, projectId, recurrenceRule } = json;
 
     // Normalize recurrence rule if provided
     if (recurrenceRule !== undefined) {

--- a/src/app/api/v1/tasks/[id]/route.ts
+++ b/src/app/api/v1/tasks/[id]/route.ts
@@ -2,6 +2,7 @@ import { Prisma } from "@prisma/client";
 import { NextRequest } from "next/server";
 
 import { v1Read, v1Write, ApiHttpError } from "@/lib/api/v1";
+import { parseOptionalApiDate } from "@/lib/api/dates";
 import { prisma } from "@/lib/prisma";
 import { deleteTaskBlockEvent, schedulePushTaskBlock } from "@/lib/task-block-push";
 import { normalizeRecurrenceRule } from "@/lib/utils/normalize-recurrence-rules";
@@ -82,10 +83,10 @@ export async function PATCH(
     if ("energyLevel" in json) updates.energyLevel = json.energyLevel;
     if ("preferredTime" in json) updates.preferredTime = json.preferredTime;
     if ("dueDate" in json) {
-      updates.dueDate = json.dueDate ? new Date(json.dueDate) : null;
+      updates.dueDate = parseOptionalApiDate(json.dueDate, "dueDate");
     }
     if ("startDate" in json) {
-      updates.startDate = json.startDate ? new Date(json.startDate) : null;
+      updates.startDate = parseOptionalApiDate(json.startDate, "startDate");
     }
 
     const { tagIds, projectId, recurrenceRule } = json;

--- a/src/app/api/v1/tasks/__tests__/route.test.ts
+++ b/src/app/api/v1/tasks/__tests__/route.test.ts
@@ -164,6 +164,29 @@ describe("POST /api/v1/tasks", () => {
     expect(Array.isArray(body)).toBe(true);
     expect(body).toHaveLength(2);
   });
+
+  it("ignores injected protected fields (no mass-assignment)", async () => {
+    const { POST } = await import("../route");
+    const create = jest.fn().mockResolvedValueOnce({ id: "t1" });
+    (prisma.task.create as jest.Mock) = create;
+
+    // Attacker tries to write another user's id + server-controlled columns.
+    const taskData = {
+      title: "Evil",
+      userId: "victim-user-id",
+      scheduledStart: "2030-01-01T00:00:00Z",
+      blockEventId: "x",
+      status: "completed",
+    };
+    const res = await POST(createRequest("POST", undefined, taskData));
+
+    expect(res.status).toBe(201);
+    const data = create.mock.calls[0][0].data;
+    expect(data.userId).toBe("test-user-id"); // authenticated user, not injected
+    expect(data.scheduledStart).toBeUndefined();
+    expect(data.blockEventId).toBeUndefined();
+    expect(data.status).toBe("completed"); // status IS allow-listed
+  });
 });
 
 describe("GET /api/v1/tasks", () => {

--- a/src/app/api/v1/tasks/__tests__/route.test.ts
+++ b/src/app/api/v1/tasks/__tests__/route.test.ts
@@ -165,6 +165,17 @@ describe("POST /api/v1/tasks", () => {
     expect(body).toHaveLength(2);
   });
 
+  it("rejects a non-RFC-3339 dueDate with 400", async () => {
+    const { POST } = await import("../route");
+    const res = await POST(
+      createRequest("POST", undefined, { title: "T", dueDate: "06/24/2026" })
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error?.code).toBe("INVALID_ARGUMENT");
+    expect(body.error?.field).toBe("dueDate");
+  });
+
   it("ignores injected protected fields (no mass-assignment)", async () => {
     const { POST } = await import("../route");
     const create = jest.fn().mockResolvedValueOnce({ id: "t1" });

--- a/src/app/api/v1/tasks/__tests__/route.test.ts
+++ b/src/app/api/v1/tasks/__tests__/route.test.ts
@@ -1,0 +1,280 @@
+import { NextRequest } from "next/server";
+
+// Mock dependencies first, before any imports of route handlers
+jest.mock("@/lib/api/idempotency", () => ({
+  runIdempotent: jest.fn(({ produce }) => produce()),
+}));
+jest.mock("@/lib/auth/api-key", () => ({
+  requireV1Auth: jest.fn(async () => ({
+    userId: "test-user-id",
+    authMethod: "api_key",
+  })),
+}));
+jest.mock("@/lib/logger");
+jest.mock("@/lib/prisma", () => ({
+  prisma: { task: {} },
+}));
+jest.mock("@/lib/task-block-push");
+jest.mock("@/lib/api/schedule-guard");
+jest.mock("@/services/scheduling/TaskSchedulingService");
+
+import { prisma } from "@/lib/prisma";
+import { autoScheduleReadiness } from "@/lib/api/schedule-guard";
+import { scheduleAllTasksForUser } from "@/services/scheduling/TaskSchedulingService";
+
+const mockAutoScheduleReadiness = autoScheduleReadiness as jest.Mock;
+const mockScheduleAllTasksForUser = scheduleAllTasksForUser as jest.Mock;
+
+function createRequest(
+  method = "POST",
+  url?: string,
+  body?: unknown
+): NextRequest {
+  return {
+    method,
+    json: async () => body,
+    headers: new Headers(),
+    url: url || "http://localhost/api/v1/tasks",
+  } as unknown as NextRequest;
+}
+
+describe("POST /api/v1/tasks", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("rejects empty title with 400", async () => {
+    const { POST } = await import("../route");
+    const taskData = { title: "" };
+    const req = createRequest("POST", undefined, taskData);
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error?.code).toBe("INVALID_ARGUMENT");
+    expect(body.error?.field).toBe("title");
+  });
+
+  it("rejects batch size over 100", async () => {
+    const { POST } = await import("../route");
+    const taskData = Array.from({ length: 101 }, (_, i) => ({
+      title: `Task ${i}`,
+    }));
+    const req = createRequest("POST", undefined, taskData);
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error?.code).toBe("INVALID_ARGUMENT");
+    expect(body.error?.message).toContain("exceeds maximum");
+  });
+
+  it("rejects when autoScheduled but user not ready", async () => {
+    const { POST } = await import("../route");
+    mockAutoScheduleReadiness.mockResolvedValueOnce({
+      ready: false,
+      reason: "Timezone not set",
+    });
+
+    const taskData = {
+      title: "Auto Task",
+      autoScheduled: { deadline: "2025-12-31" },
+    };
+    const req = createRequest("POST", undefined, taskData);
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error?.message).toContain("Timezone");
+  });
+
+  it("calls scheduleAllTasksForUser exactly once when autoScheduled", async () => {
+    const { POST } = await import("../route");
+    const taskData = [
+      { title: "Auto Task 1", autoScheduled: { deadline: "2025-12-31" } },
+      { title: "Auto Task 2", autoScheduled: { deadline: "2025-12-31" } },
+    ];
+
+    mockAutoScheduleReadiness.mockResolvedValueOnce({ ready: true });
+    (prisma.task.create as jest.Mock) = jest
+      .fn()
+      .mockResolvedValueOnce({
+        id: "t1",
+        title: "Auto Task 1",
+        userId: "test-user-id",
+      })
+      .mockResolvedValueOnce({
+        id: "t2",
+        title: "Auto Task 2",
+        userId: "test-user-id",
+      });
+    (prisma.task.findMany as jest.Mock) = jest
+      .fn()
+      .mockResolvedValueOnce([
+        { id: "t1", title: "Auto Task 1" },
+        { id: "t2", title: "Auto Task 2" },
+      ]);
+    mockScheduleAllTasksForUser.mockResolvedValueOnce([
+      { id: "t1" },
+      { id: "t2" },
+    ]);
+
+    const req = createRequest("POST", undefined, taskData);
+    const res = await POST(req);
+
+    expect(res.status).toBe(201);
+    expect(mockScheduleAllTasksForUser).toHaveBeenCalledTimes(1);
+    expect(mockScheduleAllTasksForUser).toHaveBeenCalledWith("test-user-id");
+  });
+
+  it("creates single task and returns it", async () => {
+    const { POST } = await import("../route");
+    const taskData = { title: "Single Task" };
+
+    (prisma.task.create as jest.Mock) = jest
+      .fn()
+      .mockResolvedValueOnce({
+        id: "t1",
+        title: "Single Task",
+        userId: "test-user-id",
+      });
+
+    const req = createRequest("POST", undefined, taskData);
+    const res = await POST(req);
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.id).toBe("t1");
+  });
+
+  it("creates batch of tasks and returns array", async () => {
+    const { POST } = await import("../route");
+    const taskData = [{ title: "Task 1" }, { title: "Task 2" }];
+
+    (prisma.task.create as jest.Mock) = jest
+      .fn()
+      .mockResolvedValueOnce({ id: "t1", title: "Task 1" })
+      .mockResolvedValueOnce({ id: "t2", title: "Task 2" });
+
+    const req = createRequest("POST", undefined, taskData);
+    const res = await POST(req);
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(Array.isArray(body)).toBe(true);
+    expect(body).toHaveLength(2);
+  });
+});
+
+describe("GET /api/v1/tasks", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns paginated response with has_more and next_cursor", async () => {
+    const { GET } = await import("../route");
+    const tasks = [
+      { id: "t1", title: "Task 1" },
+      { id: "t2", title: "Task 2" },
+    ];
+
+    (prisma.task.findMany as jest.Mock) = jest
+      .fn()
+      .mockResolvedValueOnce(tasks);
+
+    const req = createRequest("GET");
+    const res = await GET(req);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toHaveLength(2);
+    expect(body.has_more).toBe(false);
+    expect(body.next_cursor).toBeNull();
+  });
+
+  it("sets has_more and next_cursor when more results exist", async () => {
+    const { GET } = await import("../route");
+    const tasks = Array.from({ length: 51 }, (_, i) => ({
+      id: `t${i}`,
+      title: `Task ${i}`,
+    }));
+
+    (prisma.task.findMany as jest.Mock) = jest
+      .fn()
+      .mockResolvedValueOnce(tasks);
+
+    const req = createRequest("GET", "http://localhost/api/v1/tasks?limit=50");
+    const res = await GET(req);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toHaveLength(50);
+    expect(body.has_more).toBe(true);
+    expect(body.next_cursor).toBe("t49");
+  });
+
+  it("filters by status when provided", async () => {
+    const { GET } = await import("../route");
+    const tasks = [{ id: "t1", status: "todo" }];
+
+    (prisma.task.findMany as jest.Mock) = jest
+      .fn()
+      .mockResolvedValueOnce(tasks);
+
+    const req = createRequest(
+      "GET",
+      "http://localhost/api/v1/tasks?status=todo"
+    );
+    const res = await GET(req);
+
+    expect(res.status).toBe(200);
+    expect(prisma.task.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ status: "todo" }),
+      })
+    );
+  });
+
+  it("respects limit and caps at 500", async () => {
+    const { GET } = await import("../route");
+    const tasks = Array.from({ length: 100 }, (_, i) => ({ id: `t${i}` }));
+
+    (prisma.task.findMany as jest.Mock) = jest
+      .fn()
+      .mockResolvedValueOnce(tasks);
+
+    const req = createRequest("GET", "http://localhost/api/v1/tasks?limit=600");
+    const res = await GET(req);
+
+    expect(res.status).toBe(200);
+    expect(prisma.task.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ take: 501 })
+    );
+  });
+
+  it("uses cursor for pagination", async () => {
+    const { GET } = await import("../route");
+    const tasks = [
+      { id: "t2", title: "Task 2" },
+      { id: "t3", title: "Task 3" },
+    ];
+
+    (prisma.task.findMany as jest.Mock) = jest
+      .fn()
+      .mockResolvedValueOnce(tasks);
+
+    const req = createRequest(
+      "GET",
+      "http://localhost/api/v1/tasks?cursor=t1"
+    );
+    const res = await GET(req);
+
+    expect(res.status).toBe(200);
+    expect(prisma.task.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cursor: { id: "t1" },
+        skip: 1,
+      })
+    );
+  });
+});

--- a/src/app/api/v1/tasks/route.ts
+++ b/src/app/api/v1/tasks/route.ts
@@ -79,19 +79,23 @@ export async function POST(request: NextRequest) {
     // Create all tasks
     const createdTasks = await Promise.all(
       tasksInput.map(async (taskInput) => {
+        // Explicit allow-list of caller-settable fields. Anything else in the
+        // body (userId, scheduledStart, blockEventId, syncStatus, …) is ignored
+        // to prevent mass-assignment / cross-tenant writes via the public API.
         const {
           title,
           description,
+          status,
           duration,
           priority,
           energyLevel,
           preferredTime,
           dueDate: dueDateInput,
+          startDate,
           projectId,
           tagIds,
           recurrenceRule,
           autoScheduled,
-          ...rest
         } = taskInput;
 
         // Map Motion-style autoScheduled to internal fields
@@ -129,11 +133,13 @@ export async function POST(request: NextRequest) {
           data: {
             title,
             description: description || null,
+            status: status || "todo",
             duration: duration || 30,
             priority: priority || null,
             energyLevel: energyLevel || null,
             preferredTime: preferredTime || null,
             dueDate: mappedDueDate ? new Date(mappedDueDate) : null,
+            startDate: startDate ? new Date(startDate) : null,
             projectId: projectId || null,
             isAutoScheduled,
             isRecurring: !!recurrenceRule,
@@ -144,7 +150,6 @@ export async function POST(request: NextRequest) {
                 connect: tagIds.map((id: string) => ({ id })),
               },
             }),
-            ...rest,
           },
           include: {
             tags: true,

--- a/src/app/api/v1/tasks/route.ts
+++ b/src/app/api/v1/tasks/route.ts
@@ -1,0 +1,250 @@
+import { Prisma } from "@prisma/client";
+import { NextRequest } from "next/server";
+
+import { RRule } from "rrule";
+
+import { v1Read, v1Write, ApiHttpError } from "@/lib/api/v1";
+import { paginated } from "@/lib/api/respond";
+import { autoScheduleReadiness } from "@/lib/api/schedule-guard";
+import { logger } from "@/lib/logger";
+import { prisma } from "@/lib/prisma";
+import { schedulePushTaskBlock } from "@/lib/task-block-push";
+import { normalizeRecurrenceRule } from "@/lib/utils/normalize-recurrence-rules";
+import { scheduleAllTasksForUser } from "@/services/scheduling/TaskSchedulingService";
+
+const LOG_SOURCE = "api-v1-tasks-route";
+
+const MAX_BATCH_SIZE = 100;
+
+/**
+ * POST /api/v1/tasks — Create one or more tasks.
+ *
+ * Accept a single task object OR an array of them.
+ * - Validate title required, non-empty (INVALID_ARGUMENT)
+ * - Batch max is 100 (INVALID_ARGUMENT)
+ * - If any task has autoScheduled, call autoScheduleReadiness first
+ * - Then call scheduleAllTasksForUser ONCE (not per task)
+ * - Return single task if input was single object, array if input was array
+ */
+export async function POST(request: NextRequest) {
+  return v1Write(request, "POST /api/v1/tasks", async ({ userId }) => {
+    const json = await request.json();
+
+    // Normalize to array for uniform processing
+    const isSingleObject = !Array.isArray(json);
+    const tasksInput = isSingleObject ? [json] : json;
+
+    if (!Array.isArray(tasksInput)) {
+      throw new ApiHttpError(
+        "INVALID_ARGUMENT",
+        "Request body must be a task object or an array of tasks"
+      );
+    }
+
+    if (tasksInput.length === 0) {
+      throw new ApiHttpError(
+        "INVALID_ARGUMENT",
+        "At least one task is required"
+      );
+    }
+
+    if (tasksInput.length > MAX_BATCH_SIZE) {
+      throw new ApiHttpError(
+        "INVALID_ARGUMENT",
+        `Batch size exceeds maximum of ${MAX_BATCH_SIZE}`
+      );
+    }
+
+    // Validate all tasks have title
+    for (let i = 0; i < tasksInput.length; i++) {
+      const task = tasksInput[i];
+      if (!task.title || typeof task.title !== "string" || task.title.trim() === "") {
+        throw new ApiHttpError(
+          "INVALID_ARGUMENT",
+          "title is required and must be a non-empty string",
+          { field: "title" }
+        );
+      }
+    }
+
+    // Check if any task has autoScheduled and if so, verify readiness
+    const hasAutoScheduled = tasksInput.some((t) => t.autoScheduled);
+    if (hasAutoScheduled) {
+      const readiness = await autoScheduleReadiness(userId);
+      if (!readiness.ready) {
+        throw new ApiHttpError("INVALID_ARGUMENT", readiness.reason);
+      }
+    }
+
+    // Create all tasks
+    const createdTasks = await Promise.all(
+      tasksInput.map(async (taskInput) => {
+        const {
+          title,
+          description,
+          duration,
+          priority,
+          energyLevel,
+          preferredTime,
+          dueDate: dueDateInput,
+          projectId,
+          tagIds,
+          recurrenceRule,
+          autoScheduled,
+          ...rest
+        } = taskInput;
+
+        // Map Motion-style autoScheduled to internal fields
+        let isAutoScheduled = false;
+        let mappedDueDate = dueDateInput;
+        if (autoScheduled && typeof autoScheduled === "object") {
+          isAutoScheduled = true;
+          if (autoScheduled.deadline) {
+            mappedDueDate = autoScheduled.deadline;
+          }
+        }
+
+        // Normalize recurrence rule if provided
+        const standardizedRecurrenceRule = recurrenceRule
+          ? normalizeRecurrenceRule(recurrenceRule)
+          : undefined;
+
+        if (standardizedRecurrenceRule) {
+          try {
+            RRule.fromString(standardizedRecurrenceRule);
+          } catch (error) {
+            logger.error(
+              "Error parsing recurrence rule:",
+              {
+                error:
+                  error instanceof Error ? error.message : String(error),
+              },
+              LOG_SOURCE
+            );
+            throw new ApiHttpError("INVALID_ARGUMENT", "Invalid recurrence rule");
+          }
+        }
+
+        const task = await prisma.task.create({
+          data: {
+            title,
+            description: description || null,
+            duration: duration || 30,
+            priority: priority || null,
+            energyLevel: energyLevel || null,
+            preferredTime: preferredTime || null,
+            dueDate: mappedDueDate ? new Date(mappedDueDate) : null,
+            projectId: projectId || null,
+            isAutoScheduled,
+            isRecurring: !!recurrenceRule,
+            recurrenceRule: standardizedRecurrenceRule,
+            userId,
+            ...(tagIds && {
+              tags: {
+                connect: tagIds.map((id: string) => ({ id })),
+              },
+            }),
+            ...rest,
+          },
+          include: {
+            tags: true,
+            project: true,
+          },
+        });
+
+        return task;
+      })
+    );
+
+    // If any task was auto-scheduled, reschedule all tasks for the user ONCE
+    if (hasAutoScheduled) {
+      await scheduleAllTasksForUser(userId);
+      // Re-fetch the created tasks to get their scheduled positions
+      const refreshedTasks = await prisma.task.findMany({
+        where: { userId, id: { in: createdTasks.map((t) => t.id) } },
+        include: {
+          tags: true,
+          project: true,
+        },
+      });
+      // Replace createdTasks with refreshed versions (now positioned)
+      for (let i = 0; i < createdTasks.length; i++) {
+        const refreshed = refreshedTasks.find((t) => t.id === createdTasks[i].id);
+        if (refreshed) {
+          Object.assign(createdTasks[i], refreshed);
+        }
+      }
+    } else {
+      // Schedule calendar blocks for tasks with scheduledStart/End
+      for (const task of createdTasks) {
+        if (task.scheduledStart && task.scheduledEnd) {
+          schedulePushTaskBlock(userId, task.id);
+        }
+      }
+    }
+
+    // Return single task if input was single, array if input was array
+    const responseBody = isSingleObject ? createdTasks[0] : createdTasks;
+
+    return {
+      status: 201,
+      body: responseBody,
+    };
+  });
+}
+
+/**
+ * GET /api/v1/tasks — List the user's tasks with cursor pagination.
+ *
+ * Query params:
+ *  - cursor: opaque pagination cursor
+ *  - limit: max items (default 50, max 500)
+ *  - status: optional filter
+ *
+ * Stable sort by (createdAt, id) desc.
+ */
+export async function GET(request: NextRequest) {
+  return v1Read(request, async ({ userId }) => {
+    const { searchParams } = new URL(request.url);
+    const cursor = searchParams.get("cursor");
+    const limitStr = searchParams.get("limit") || "50";
+    const status = searchParams.get("status");
+
+    const limit = Math.min(Math.max(1, parseInt(limitStr, 10) || 50), 500);
+
+    // Decode cursor if provided (it's the id of the last item from prev page)
+    let skip = 0;
+    let skipId: string | undefined;
+    if (cursor) {
+      skipId = cursor;
+      skip = 1; // Skip the cursor itself to avoid duplication
+    }
+
+    // Build the query
+    const where: Prisma.TaskWhereInput = { userId };
+    if (status) {
+      where.status = status;
+    }
+
+    // Get limit + 1 to determine if there's a next page
+    const rows = await prisma.task.findMany({
+      where,
+      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+      take: limit + 1,
+      ...(skipId && { cursor: { id: skipId }, skip }),
+      include: {
+        tags: true,
+        project: true,
+      },
+    });
+
+    const hasMore = rows.length > limit;
+    const data = rows.slice(0, limit);
+    const nextCursor = hasMore ? data[data.length - 1]?.id || null : null;
+
+    return {
+      status: 200,
+      body: paginated(data, nextCursor),
+    };
+  });
+}

--- a/src/app/api/v1/tasks/route.ts
+++ b/src/app/api/v1/tasks/route.ts
@@ -9,7 +9,7 @@ import { paginated } from "@/lib/api/respond";
 import { autoScheduleReadiness } from "@/lib/api/schedule-guard";
 import { logger } from "@/lib/logger";
 import { prisma } from "@/lib/prisma";
-import { schedulePushTaskBlock } from "@/lib/task-block-push";
+import { repushDirtyBlocks, schedulePushTaskBlock } from "@/lib/task-block-push";
 import { normalizeRecurrenceRule } from "@/lib/utils/normalize-recurrence-rules";
 import { scheduleAllTasksForUser } from "@/services/scheduling/TaskSchedulingService";
 
@@ -171,6 +171,9 @@ export async function POST(request: NextRequest) {
     // If any task was auto-scheduled, reschedule all tasks for the user ONCE
     if (hasAutoScheduled) {
       await scheduleAllTasksForUser(userId);
+      // Push the newly-scheduled blocks to the calendar (if the user has
+      // task→calendar push enabled) — mirrors the internal schedule-all route.
+      await repushDirtyBlocks(userId);
       // Re-fetch the created tasks to get their scheduled positions
       const refreshedTasks = await prisma.task.findMany({
         where: { userId, id: { in: createdTasks.map((t) => t.id) } },

--- a/src/app/api/v1/tasks/route.ts
+++ b/src/app/api/v1/tasks/route.ts
@@ -4,6 +4,7 @@ import { NextRequest } from "next/server";
 import { RRule } from "rrule";
 
 import { v1Read, v1Write, ApiHttpError } from "@/lib/api/v1";
+import { parseApiDate, parseOptionalApiDate } from "@/lib/api/dates";
 import { paginated } from "@/lib/api/respond";
 import { autoScheduleReadiness } from "@/lib/api/schedule-guard";
 import { logger } from "@/lib/logger";
@@ -55,7 +56,8 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Validate all tasks have title
+    // Validate every item up front (titles + RFC 3339 dates) so a bad item
+    // fails the whole request before any task is created.
     for (let i = 0; i < tasksInput.length; i++) {
       const task = tasksInput[i];
       if (!task.title || typeof task.title !== "string" || task.title.trim() === "") {
@@ -64,6 +66,11 @@ export async function POST(request: NextRequest) {
           "title is required and must be a non-empty string",
           { field: "title" }
         );
+      }
+      parseOptionalApiDate(task.dueDate, "dueDate");
+      parseOptionalApiDate(task.startDate, "startDate");
+      if (task.autoScheduled?.deadline !== undefined) {
+        parseApiDate(task.autoScheduled.deadline, "autoScheduled.deadline");
       }
     }
 
@@ -138,8 +145,8 @@ export async function POST(request: NextRequest) {
             priority: priority || null,
             energyLevel: energyLevel || null,
             preferredTime: preferredTime || null,
-            dueDate: mappedDueDate ? new Date(mappedDueDate) : null,
-            startDate: startDate ? new Date(startDate) : null,
+            dueDate: parseOptionalApiDate(mappedDueDate, "dueDate"),
+            startDate: parseOptionalApiDate(startDate, "startDate"),
             projectId: projectId || null,
             isAutoScheduled,
             isRecurring: !!recurrenceRule,

--- a/src/components/settings/ApiSettings.tsx
+++ b/src/components/settings/ApiSettings.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import { toast } from "sonner";
+
+import { CreateApiKeyModal } from "@/components/settings/CreateApiKeyModal";
+import { SettingRow, SettingsSection } from "@/components/settings/SettingsSection";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Switch } from "@/components/ui/switch";
+
+interface ApiKeyRow {
+  id: string;
+  name: string;
+  keyPrefix: string;
+  lastUsedAt: string | null;
+  createdAt: string;
+  revokedAt: string | null;
+}
+
+function formatDate(value: string | null): string {
+  if (!value) return "—";
+  return new Date(value).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+export function ApiSettings() {
+  const [enabled, setEnabled] = useState<boolean | null>(null);
+  const [keys, setKeys] = useState<ApiKeyRow[]>([]);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [revokeTarget, setRevokeTarget] = useState<ApiKeyRow | null>(null);
+
+  const loadKeys = useCallback(async () => {
+    try {
+      const res = await fetch("/api/api-keys");
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json();
+      setKeys(data.keys ?? []);
+    } catch {
+      toast.error("Failed to load API keys.");
+    }
+  }, []);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await fetch("/api/api-settings");
+        if (res.ok) {
+          const data = await res.json();
+          setEnabled(Boolean(data.enabled));
+        } else {
+          setEnabled(false);
+        }
+      } catch {
+        setEnabled(false);
+      }
+    })();
+    loadKeys();
+  }, [loadKeys]);
+
+  const toggleEnabled = async (next: boolean) => {
+    const previous = enabled;
+    setEnabled(next); // optimistic
+    try {
+      const res = await fetch("/api/api-settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ enabled: next }),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      toast.success(next ? "API access enabled." : "API access disabled.");
+    } catch {
+      setEnabled(previous ?? false);
+      toast.error("Failed to update API access.");
+    }
+  };
+
+  const revokeKey = async () => {
+    if (!revokeTarget) return;
+    try {
+      const res = await fetch(`/api/api-keys/${revokeTarget.id}`, {
+        method: "DELETE",
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      toast.success("API key revoked.");
+      setRevokeTarget(null);
+      loadKeys();
+    } catch {
+      toast.error("Failed to revoke API key.");
+    }
+  };
+
+  const activeKeys = keys.filter((k) => !k.revokedAt);
+
+  return (
+    <SettingsSection
+      title="API & Developer"
+      description="Programmatic access to your tasks and calendar. Use API keys to let external tools (automation, meeting assistants, scripts) create and schedule items on your behalf."
+    >
+      <SettingRow
+        label="Enable API access"
+        description="When off, all of your API keys are rejected. Turn on to use the /api/v1 endpoints."
+      >
+        <Switch
+          checked={enabled ?? false}
+          disabled={enabled === null}
+          onCheckedChange={toggleEnabled}
+          aria-label="Enable API access"
+        />
+      </SettingRow>
+
+      {enabled && (
+        <SettingRow
+          label="API keys"
+          description="Keys are shown in full only once at creation. Revoke any key you no longer use."
+        >
+          <div className="space-y-4">
+            <div className="flex justify-end">
+              <Button type="button" onClick={() => setCreateOpen(true)}>
+                Create key
+              </Button>
+            </div>
+
+            {activeKeys.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                No active API keys yet.
+              </p>
+            ) : (
+              <div className="overflow-hidden rounded-md border">
+                <table className="w-full text-sm">
+                  <thead className="bg-muted/50 text-muted-foreground">
+                    <tr>
+                      <th className="px-3 py-2 text-left font-medium">Name</th>
+                      <th className="px-3 py-2 text-left font-medium">Prefix</th>
+                      <th className="px-3 py-2 text-left font-medium">
+                        Last used
+                      </th>
+                      <th className="px-3 py-2 text-left font-medium">Created</th>
+                      <th className="px-3 py-2" />
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {activeKeys.map((k) => (
+                      <tr key={k.id} className="border-t">
+                        <td className="px-3 py-2">{k.name}</td>
+                        <td className="px-3 py-2">
+                          <code className="text-xs">{k.keyPrefix}…</code>
+                        </td>
+                        <td className="px-3 py-2">{formatDate(k.lastUsedAt)}</td>
+                        <td className="px-3 py-2">{formatDate(k.createdAt)}</td>
+                        <td className="px-3 py-2 text-right">
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            onClick={() => setRevokeTarget(k)}
+                          >
+                            Revoke
+                          </Button>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        </SettingRow>
+      )}
+
+      <CreateApiKeyModal
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        onCreated={loadKeys}
+      />
+
+      <Dialog
+        open={revokeTarget !== null}
+        onOpenChange={(o) => !o && setRevokeTarget(null)}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Revoke API key</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            Revoking <span className="font-medium">{revokeTarget?.name}</span>{" "}
+            immediately stops any integration using it. This cannot be undone.
+          </p>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setRevokeTarget(null)}
+            >
+              Cancel
+            </Button>
+            <Button type="button" variant="destructive" onClick={revokeKey}>
+              Revoke
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </SettingsSection>
+  );
+}

--- a/src/components/settings/CreateApiKeyModal.tsx
+++ b/src/components/settings/CreateApiKeyModal.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useState } from "react";
+
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+interface CreateApiKeyModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onCreated: () => void;
+}
+
+export function CreateApiKeyModal({
+  open,
+  onOpenChange,
+  onCreated,
+}: CreateApiKeyModalProps) {
+  const [name, setName] = useState("");
+  const [creating, setCreating] = useState(false);
+  // The plaintext key is returned exactly once by the API and never again.
+  const [createdKey, setCreatedKey] = useState<string | null>(null);
+
+  const reset = () => {
+    setName("");
+    setCreating(false);
+    setCreatedKey(null);
+  };
+
+  const handleClose = (next: boolean) => {
+    if (!next) reset();
+    onOpenChange(next);
+  };
+
+  const handleCreate = async () => {
+    if (!name.trim()) {
+      toast.error("Please enter a name for the key.");
+      return;
+    }
+    setCreating(true);
+    try {
+      const res = await fetch("/api/api-keys", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: name.trim() }),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json();
+      setCreatedKey(data.key);
+      onCreated();
+    } catch {
+      toast.error("Failed to create API key.");
+      setCreating(false);
+    }
+  };
+
+  const handleCopy = async () => {
+    if (!createdKey) return;
+    await navigator.clipboard.writeText(createdKey);
+    toast.success("Copied to clipboard.");
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>
+            {createdKey ? "Save your API key" : "Create API key"}
+          </DialogTitle>
+        </DialogHeader>
+
+        {createdKey ? (
+          <div className="space-y-3">
+            <p className="text-sm text-muted-foreground">
+              Copy this key now. For security it is shown{" "}
+              <span className="font-medium">only once</span> and cannot be
+              retrieved again.
+            </p>
+            <div className="flex items-center gap-2">
+              <code className="flex-1 break-all rounded-md bg-muted px-3 py-2 text-xs">
+                {createdKey}
+              </code>
+              <Button type="button" variant="outline" onClick={handleCopy}>
+                Copy
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            <Label htmlFor="api-key-name">Key name</Label>
+            <Input
+              id="api-key-name"
+              placeholder="e.g. Meeting-notes bot"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              maxLength={100}
+              autoFocus
+            />
+            <p className="text-sm text-muted-foreground">
+              A label to help you recognize where this key is used.
+            </p>
+          </div>
+        )}
+
+        <DialogFooter>
+          {createdKey ? (
+            <Button type="button" onClick={() => handleClose(false)}>
+              Done
+            </Button>
+          ) : (
+            <>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => handleClose(false)}
+              >
+                Cancel
+              </Button>
+              <Button type="button" onClick={handleCreate} disabled={creating}>
+                {creating ? "Creating..." : "Create key"}
+              </Button>
+            </>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/lib/api/__tests__/dates.test.ts
+++ b/src/lib/api/__tests__/dates.test.ts
@@ -1,0 +1,65 @@
+import { ApiHttpError } from "@/lib/api/v1";
+import { parseApiDate, parseOptionalApiDate } from "@/lib/api/dates";
+
+describe("parseApiDate", () => {
+  it("accepts RFC 3339 date-times with offsets", () => {
+    expect(parseApiDate("2026-06-24T15:00:00Z", "start").toISOString()).toBe(
+      "2026-06-24T15:00:00.000Z"
+    );
+    expect(parseApiDate("2026-06-24T17:00:00+02:00", "start").toISOString()).toBe(
+      "2026-06-24T15:00:00.000Z"
+    );
+    expect(parseApiDate("2026-06-24T15:00:00.500Z", "start")).toBeInstanceOf(
+      Date
+    );
+  });
+
+  it("accepts a calendar date as UTC midnight", () => {
+    expect(parseApiDate("2026-06-24", "from").toISOString()).toBe(
+      "2026-06-24T00:00:00.000Z"
+    );
+  });
+
+  it("rejects non-RFC-3339 strings", () => {
+    for (const bad of [
+      "tomorrow",
+      "06/24/2026",
+      "2026-06-24T15:00:00", // no offset
+      "2026-13-01T00:00:00Z", // impossible month
+      "not-a-date",
+      "",
+    ]) {
+      expect(() => parseApiDate(bad, "start")).toThrow(ApiHttpError);
+    }
+  });
+
+  it("rejects non-string input", () => {
+    expect(() => parseApiDate(1750000000000, "start")).toThrow(ApiHttpError);
+    expect(() => parseApiDate(null, "start")).toThrow(ApiHttpError);
+  });
+
+  it("surfaces the offending field on the error", () => {
+    try {
+      parseApiDate("nope", "dueDate");
+      fail("should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(ApiHttpError);
+      expect((e as ApiHttpError).opts?.field).toBe("dueDate");
+    }
+  });
+});
+
+describe("parseOptionalApiDate", () => {
+  it("returns null for empty values", () => {
+    expect(parseOptionalApiDate(undefined, "x")).toBeNull();
+    expect(parseOptionalApiDate(null, "x")).toBeNull();
+    expect(parseOptionalApiDate("", "x")).toBeNull();
+  });
+
+  it("validates when a value is present", () => {
+    expect(parseOptionalApiDate("2026-06-24T15:00:00Z", "x")).toBeInstanceOf(
+      Date
+    );
+    expect(() => parseOptionalApiDate("bad", "x")).toThrow(ApiHttpError);
+  });
+});

--- a/src/lib/api/__tests__/schedule-guard.test.ts
+++ b/src/lib/api/__tests__/schedule-guard.test.ts
@@ -1,0 +1,39 @@
+import { autoScheduleReadiness } from "@/lib/api/schedule-guard";
+import { prisma } from "@/lib/prisma";
+
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    autoScheduleSettings: { findUnique: jest.fn() },
+    userSettings: { findUnique: jest.fn() },
+  },
+}));
+
+const mockAuto = prisma.autoScheduleSettings as unknown as {
+  findUnique: jest.Mock;
+};
+const mockUser = prisma.userSettings as unknown as { findUnique: jest.Mock };
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("autoScheduleReadiness", () => {
+  it("is ready when settings exist and a (non-UTC) timezone is set", async () => {
+    mockAuto.findUnique.mockResolvedValue({ id: "s1" });
+    mockUser.findUnique.mockResolvedValue({ timeZone: "America/Chicago" });
+    await expect(autoScheduleReadiness("u1")).resolves.toEqual({ ready: true });
+  });
+
+  it("is not ready when auto-schedule settings are missing", async () => {
+    mockAuto.findUnique.mockResolvedValue(null);
+    mockUser.findUnique.mockResolvedValue({ timeZone: "America/Chicago" });
+    const result = await autoScheduleReadiness("u1");
+    expect(result.ready).toBe(false);
+  });
+
+  it("is not ready when the timezone is missing (prevents wrong-tz scheduling)", async () => {
+    mockAuto.findUnique.mockResolvedValue({ id: "s1" });
+    mockUser.findUnique.mockResolvedValue({ timeZone: null });
+    const result = await autoScheduleReadiness("u1");
+    expect(result.ready).toBe(false);
+    if (!result.ready) expect(result.reason).toMatch(/timezone/i);
+  });
+});

--- a/src/lib/api/__tests__/v1.test.ts
+++ b/src/lib/api/__tests__/v1.test.ts
@@ -1,0 +1,98 @@
+import { NextRequest } from "next/server";
+
+import { requireV1Auth } from "@/lib/auth/api-key";
+import { runIdempotent } from "@/lib/api/idempotency";
+import { _resetRateLimitBuckets } from "@/lib/api/rate-limit";
+import { ApiHttpError, v1Read, v1Write } from "@/lib/api/v1";
+
+jest.mock("@/lib/auth/api-key", () => ({ requireV1Auth: jest.fn() }));
+jest.mock("@/lib/logger", () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn() },
+}));
+// Pass-through idempotency: just run produce (tested separately).
+jest.mock("@/lib/api/idempotency", () => ({
+  runIdempotent: jest.fn(({ produce }) => produce()),
+}));
+
+const mockAuth = requireV1Auth as unknown as jest.Mock;
+const mockIdem = runIdempotent as unknown as jest.Mock;
+
+function req(headers: Record<string, string> = {}): NextRequest {
+  return { headers: new Headers(headers) } as unknown as NextRequest;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  _resetRateLimitBuckets();
+  mockIdem.mockImplementation(({ produce }) => produce());
+});
+
+describe("v1Write", () => {
+  it("returns the produced body with rate-limit headers on success", async () => {
+    mockAuth.mockResolvedValue({ userId: "u1", authMethod: "api_key" });
+    const res = await v1Write(req(), "POST /x", async () => ({
+      status: 201,
+      body: { id: "t1" },
+    }));
+    expect(res.status).toBe(201);
+    expect(res.headers.get("X-RateLimit-Limit")).toBeTruthy();
+    await expect(res.json()).resolves.toEqual({ id: "t1" });
+  });
+
+  it("maps an auth error to the envelope without running the body", async () => {
+    mockAuth.mockResolvedValue({ error: "forbidden" });
+    const produce = jest.fn();
+    const res = await v1Write(req(), "POST /x", produce);
+    expect(res.status).toBe(403);
+    expect(produce).not.toHaveBeenCalled();
+  });
+
+  it("maps a thrown ApiHttpError to the right status + field", async () => {
+    mockAuth.mockResolvedValue({ userId: "u1", authMethod: "api_key" });
+    const res = await v1Write(req(), "POST /x", async () => {
+      throw new ApiHttpError("INVALID_ARGUMENT", "title is required", {
+        field: "title",
+      });
+    });
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      error: { code: "INVALID_ARGUMENT", message: "title is required", field: "title" },
+    });
+  });
+
+  it("returns 429 once the per-user limit is exceeded", async () => {
+    mockAuth.mockResolvedValue({ userId: "u2", authMethod: "api_key" });
+    let last;
+    for (let i = 0; i < 3; i++) {
+      last = await v1Write(req(), "POST /x", async () => ({ status: 200, body: {} }), {
+        bucket: "tiny",
+        limit: 2,
+      });
+    }
+    expect(last!.status).toBe(429);
+    expect(last!.headers.get("Retry-After")).toBeTruthy();
+  });
+
+  it("hands the Idempotency-Key through to runIdempotent", async () => {
+    mockAuth.mockResolvedValue({ userId: "u1", authMethod: "api_key" });
+    await v1Write(req({ "idempotency-key": "abc" }), "POST /x", async () => ({
+      status: 201,
+      body: {},
+    }));
+    expect(mockIdem).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: "u1", key: "abc", route: "POST /x" })
+    );
+  });
+});
+
+describe("v1Read", () => {
+  it("returns produced body and does not use idempotency", async () => {
+    mockAuth.mockResolvedValue({ userId: "u1", authMethod: "session" });
+    const res = await v1Read(req(), async () => ({
+      status: 200,
+      body: { data: [], next_cursor: null, has_more: false },
+    }));
+    expect(res.status).toBe(200);
+    expect(mockIdem).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/api/dates.ts
+++ b/src/lib/api/dates.ts
@@ -1,0 +1,47 @@
+import { ApiHttpError } from "@/lib/api/v1";
+
+/**
+ * Strict RFC 3339 date parsing for the public API.
+ *
+ * `new Date(str)` is permissive and engine-dependent (it will happily accept
+ * "tomorrow", "06/24/2026", or silently produce Invalid Date), which is a
+ * footgun for a calendar API with a history of timezone bugs. We instead
+ * require a well-formed RFC 3339 value — either a full date-time with an
+ * explicit offset (`2026-06-24T15:00:00Z` / `…+02:00`) or a calendar date
+ * (`2026-06-24`, interpreted as UTC midnight) — and reject anything else with a
+ * clear 400.
+ */
+
+const DATE_TIME =
+  /^\d{4}-\d{2}-\d{2}[Tt]\d{2}:\d{2}:\d{2}(\.\d+)?([Zz]|[+-]\d{2}:\d{2})$/;
+const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
+
+/** Parse a required RFC 3339 date/date-time, or throw INVALID_ARGUMENT. */
+export function parseApiDate(value: unknown, field: string): Date {
+  if (
+    typeof value !== "string" ||
+    (!DATE_TIME.test(value) && !DATE_ONLY.test(value))
+  ) {
+    throw new ApiHttpError(
+      "INVALID_ARGUMENT",
+      `${field} must be an RFC 3339 date or date-time (e.g. 2026-06-24T15:00:00Z)`,
+      { field }
+    );
+  }
+  const date = new Date(value);
+  if (isNaN(date.getTime())) {
+    throw new ApiHttpError("INVALID_ARGUMENT", `${field} is not a valid date`, {
+      field,
+    });
+  }
+  return date;
+}
+
+/** Parse an optional date — returns null for null/undefined/empty. */
+export function parseOptionalApiDate(
+  value: unknown,
+  field: string
+): Date | null {
+  if (value === undefined || value === null || value === "") return null;
+  return parseApiDate(value, field);
+}

--- a/src/lib/api/idempotency.ts
+++ b/src/lib/api/idempotency.ts
@@ -3,7 +3,28 @@ import { prisma } from "@/lib/prisma";
 
 const LOG_SOURCE = "ApiIdempotency";
 
+const RETENTION_MS = 7 * 24 * 60 * 60 * 1000; // keys replay-protect for 7 days
+
 export type IdempotentResult = { status: number; body: unknown };
+
+// Opportunistic TTL prune (every N stored keys) so the table can't grow
+// unbounded; uses the createdAt index. Fire-and-forget, never blocks a write.
+let storesSincePrune = 0;
+function maybePruneOld(): void {
+  if (++storesSincePrune < 200) return;
+  storesSincePrune = 0;
+  prisma.idempotencyKey
+    .deleteMany({
+      where: { createdAt: { lt: new Date(Date.now() - RETENTION_MS) } },
+    })
+    .catch((error) =>
+      logger.error(
+        "Failed to prune idempotency keys",
+        { error: error instanceof Error ? error.message : "unknown" },
+        LOG_SOURCE
+      )
+    );
+}
 
 /**
  * Replay-safe writes for /api/v1. When the caller sends an `Idempotency-Key`,
@@ -42,6 +63,7 @@ export async function runIdempotent(params: {
           responseJson: result.body as object,
         },
       });
+      maybePruneOld();
     } catch (error) {
       // Concurrent first request won the unique race — return the stored copy.
       const raced = await prisma.idempotencyKey.findUnique({

--- a/src/lib/api/idempotency.ts
+++ b/src/lib/api/idempotency.ts
@@ -1,0 +1,61 @@
+import { logger } from "@/lib/logger";
+import { prisma } from "@/lib/prisma";
+
+const LOG_SOURCE = "ApiIdempotency";
+
+export type IdempotentResult = { status: number; body: unknown };
+
+/**
+ * Replay-safe writes for /api/v1. When the caller sends an `Idempotency-Key`,
+ * the first successful (2xx) response is stored per (userId, key) and returned
+ * verbatim on any later replay — so AI/webhook retries can't double-create.
+ *
+ * Non-2xx results are NOT stored, so a transient failure stays retryable.
+ */
+export async function runIdempotent(params: {
+  userId: string;
+  key: string | null;
+  route: string;
+  produce: () => Promise<IdempotentResult>;
+}): Promise<IdempotentResult> {
+  const { userId, key, route, produce } = params;
+  if (!key) return produce();
+
+  const existing = await prisma.idempotencyKey.findUnique({
+    where: { userId_key: { userId, key } },
+    select: { statusCode: true, responseJson: true },
+  });
+  if (existing) {
+    return { status: existing.statusCode, body: existing.responseJson };
+  }
+
+  const result = await produce();
+
+  if (result.status >= 200 && result.status < 300) {
+    try {
+      await prisma.idempotencyKey.create({
+        data: {
+          userId,
+          key,
+          route,
+          statusCode: result.status,
+          responseJson: result.body as object,
+        },
+      });
+    } catch (error) {
+      // Concurrent first request won the unique race — return the stored copy.
+      const raced = await prisma.idempotencyKey.findUnique({
+        where: { userId_key: { userId, key } },
+        select: { statusCode: true, responseJson: true },
+      });
+      if (raced) return { status: raced.statusCode, body: raced.responseJson };
+      logger.error(
+        "Failed to persist idempotency key",
+        { error: error instanceof Error ? error.message : "unknown", route },
+        LOG_SOURCE
+      );
+    }
+  }
+
+  return result;
+}

--- a/src/lib/api/rate-limit.ts
+++ b/src/lib/api/rate-limit.ts
@@ -10,6 +10,17 @@ type Window = { count: number; resetAt: number };
 
 const buckets = new Map<string, Window>();
 
+// Opportunistic eviction so the map can't grow unbounded with one entry per
+// (user, bucket). Swept every N calls rather than on a timer (serverless-safe).
+let opsSinceSweep = 0;
+function maybeSweep(now: number): void {
+  if (++opsSinceSweep < 500) return;
+  opsSinceSweep = 0;
+  for (const [key, win] of buckets) {
+    if (win.resetAt <= now) buckets.delete(key);
+  }
+}
+
 export type RateLimitState = {
   allowed: boolean;
   limit: number;
@@ -29,6 +40,7 @@ export function rateLimit(
   const limit = opts?.limit ?? 120;
   const windowMs = opts?.windowMs ?? 60_000;
   const now = Date.now();
+  maybeSweep(now);
 
   let win = buckets.get(bucketKey);
   if (!win || win.resetAt <= now) {

--- a/src/lib/api/rate-limit.ts
+++ b/src/lib/api/rate-limit.ts
@@ -1,0 +1,58 @@
+/**
+ * Minimal in-memory fixed-window rate limiter for the /api/v1 surface.
+ *
+ * Scoped to a single app instance (sufficient for the current single-container
+ * deploy). A distributed limiter (Redis) is a Phase-2 concern; the call sites
+ * and headers are designed so that swap is transparent.
+ */
+
+type Window = { count: number; resetAt: number };
+
+const buckets = new Map<string, Window>();
+
+export type RateLimitState = {
+  allowed: boolean;
+  limit: number;
+  remaining: number;
+  reset: number; // unix seconds
+  retryAfter?: number; // seconds, only when blocked
+};
+
+/**
+ * Consume one token from `bucketKey`. Default: 120 requests / 60s.
+ * Use a tighter limit on the expensive scheduler path.
+ */
+export function rateLimit(
+  bucketKey: string,
+  opts?: { limit?: number; windowMs?: number }
+): RateLimitState {
+  const limit = opts?.limit ?? 120;
+  const windowMs = opts?.windowMs ?? 60_000;
+  const now = Date.now();
+
+  let win = buckets.get(bucketKey);
+  if (!win || win.resetAt <= now) {
+    win = { count: 0, resetAt: now + windowMs };
+    buckets.set(bucketKey, win);
+  }
+
+  win.count += 1;
+  const reset = Math.ceil(win.resetAt / 1000);
+
+  if (win.count > limit) {
+    return {
+      allowed: false,
+      limit,
+      remaining: 0,
+      reset,
+      retryAfter: Math.max(1, Math.ceil((win.resetAt - now) / 1000)),
+    };
+  }
+
+  return { allowed: true, limit, remaining: limit - win.count, reset };
+}
+
+/** Test/maintenance helper. */
+export function _resetRateLimitBuckets(): void {
+  buckets.clear();
+}

--- a/src/lib/api/respond.ts
+++ b/src/lib/api/respond.ts
@@ -1,0 +1,91 @@
+import { NextResponse } from "next/server";
+
+import type { ApiKeyError } from "@/lib/auth/api-key";
+
+/**
+ * Consistent response envelope for the /api/v1 public surface.
+ * Errors follow `{ error: { code, message, field?, retry_after? } }`
+ * (Todoist/Cal.com shape); success returns the resource/list body directly.
+ */
+
+export type ApiErrorCode =
+  | "UNAUTHORIZED"
+  | "FORBIDDEN"
+  | "INVALID_ARGUMENT"
+  | "NOT_FOUND"
+  | "CONFLICT"
+  | "RATE_LIMITED"
+  | "INTERNAL";
+
+const STATUS_BY_CODE: Record<ApiErrorCode, number> = {
+  UNAUTHORIZED: 401,
+  FORBIDDEN: 403,
+  INVALID_ARGUMENT: 400,
+  NOT_FOUND: 404,
+  CONFLICT: 409,
+  RATE_LIMITED: 429,
+  INTERNAL: 500,
+};
+
+export function ok<T>(
+  body: T,
+  init?: { status?: number; headers?: Record<string, string> }
+): NextResponse {
+  return NextResponse.json(body, {
+    status: init?.status ?? 200,
+    headers: init?.headers,
+  });
+}
+
+export function apiError(
+  code: ApiErrorCode,
+  message: string,
+  opts?: {
+    field?: string;
+    retryAfter?: number;
+    headers?: Record<string, string>;
+  }
+): NextResponse {
+  const status = STATUS_BY_CODE[code];
+  const headers: Record<string, string> = { ...(opts?.headers ?? {}) };
+  if (opts?.retryAfter != null) headers["Retry-After"] = String(opts.retryAfter);
+  return NextResponse.json(
+    {
+      error: {
+        code,
+        message,
+        ...(opts?.field ? { field: opts.field } : {}),
+        ...(opts?.retryAfter != null ? { retry_after: opts.retryAfter } : {}),
+      },
+    },
+    { status, headers }
+  );
+}
+
+/** Map an auth failure code from requireV1Auth to the error envelope. */
+export function authErrorResponse(error: ApiKeyError): NextResponse {
+  return error === "forbidden"
+    ? apiError("FORBIDDEN", "API access is not enabled for this account.")
+    : apiError("UNAUTHORIZED", "Invalid or missing API credentials.");
+}
+
+/** Standard X-RateLimit-* headers for a bucket result. */
+export function rateLimitHeaders(state: {
+  limit: number;
+  remaining: number;
+  reset: number; // unix seconds
+}): Record<string, string> {
+  return {
+    "X-RateLimit-Limit": String(state.limit),
+    "X-RateLimit-Remaining": String(state.remaining),
+    "X-RateLimit-Reset": String(state.reset),
+  };
+}
+
+/** Shape for paginated list responses: `{ data, next_cursor, has_more }`. */
+export function paginated<T>(
+  data: T[],
+  nextCursor: string | null
+): { data: T[]; next_cursor: string | null; has_more: boolean } {
+  return { data, next_cursor: nextCursor, has_more: nextCursor !== null };
+}

--- a/src/lib/api/schedule-guard.ts
+++ b/src/lib/api/schedule-guard.ts
@@ -1,0 +1,46 @@
+import { prisma } from "@/lib/prisma";
+
+/**
+ * Readiness check for auto-scheduling via the API.
+ *
+ * The scheduler (TaskSchedulingService → SchedulingService → TimeSlotManager)
+ * resolves the user's timezone from `UserSettings.timeZone` and threads it
+ * explicitly into slot calculation. The ONE gap for keyless API requests is
+ * when that timezone (or AutoScheduleSettings) was never configured: the
+ * TimeSlotManager would then fall back to the client settings store, which on
+ * the server holds no user state — silently scheduling in the wrong timezone
+ * (a 9am task could land at midnight).
+ *
+ * Rather than mis-schedule, the v1 task/schedule endpoints call this first and
+ * return 400 with a clear hint when the user isn't set up.
+ */
+export async function autoScheduleReadiness(
+  userId: string
+): Promise<{ ready: true } | { ready: false; reason: string }> {
+  const [settings, userSettings] = await Promise.all([
+    prisma.autoScheduleSettings.findUnique({
+      where: { userId },
+      select: { id: true },
+    }),
+    prisma.userSettings.findUnique({
+      where: { userId },
+      select: { timeZone: true },
+    }),
+  ]);
+
+  if (!settings) {
+    return {
+      ready: false,
+      reason:
+        "Auto-scheduling is not configured for this account. Open FluidCalendar and set up auto-schedule settings before scheduling via the API.",
+    };
+  }
+  if (!userSettings?.timeZone) {
+    return {
+      ready: false,
+      reason:
+        "No timezone is set for this account. Set your timezone in FluidCalendar settings before scheduling via the API, otherwise tasks would be placed in the wrong timezone.",
+    };
+  }
+  return { ready: true };
+}

--- a/src/lib/api/v1.ts
+++ b/src/lib/api/v1.ts
@@ -1,0 +1,124 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { logger } from "@/lib/logger";
+
+import { requireV1Auth } from "@/lib/auth/api-key";
+import { runIdempotent } from "@/lib/api/idempotency";
+import { rateLimit } from "@/lib/api/rate-limit";
+import {
+  ApiErrorCode,
+  apiError,
+  authErrorResponse,
+  ok,
+  rateLimitHeaders,
+} from "@/lib/api/respond";
+
+const LOG_SOURCE = "ApiV1";
+
+/**
+ * Throw from a handler body to return a specific error envelope.
+ * e.g. `throw new ApiHttpError("INVALID_ARGUMENT", "title is required", { field: "title" })`
+ */
+export class ApiHttpError extends Error {
+  constructor(
+    public code: ApiErrorCode,
+    message: string,
+    public opts?: { field?: string; retryAfter?: number }
+  ) {
+    super(message);
+    this.name = "ApiHttpError";
+  }
+}
+
+export type V1Context = { userId: string; request: NextRequest };
+export type V1Result = { status: number; body: unknown };
+
+type RlOpts = { bucket?: string; limit?: number; windowMs?: number };
+
+function checkRateLimit(userId: string, opts?: RlOpts) {
+  const key = `v1:${opts?.bucket ?? "default"}:${userId}`;
+  return rateLimit(key, { limit: opts?.limit, windowMs: opts?.windowMs });
+}
+
+function handleThrown(error: unknown, headers: Record<string, string>) {
+  if (error instanceof ApiHttpError) {
+    return apiError(error.code, error.message, {
+      field: error.opts?.field,
+      retryAfter: error.opts?.retryAfter,
+      headers,
+    });
+  }
+  logger.error(
+    "Unhandled error in /api/v1 handler",
+    { error: error instanceof Error ? error.message : "unknown" },
+    LOG_SOURCE
+  );
+  return apiError("INTERNAL", "An unexpected error occurred.", { headers });
+}
+
+/**
+ * Wrap a v1 WRITE handler: auth → rate-limit → idempotency → envelope.
+ * The body returns `{ status, body }`; throw `ApiHttpError` for error envelopes.
+ * `Idempotency-Key` replays the first 2xx response.
+ */
+export async function v1Write(
+  request: NextRequest,
+  routeLabel: string,
+  produce: (ctx: V1Context) => Promise<V1Result>,
+  rlOpts?: RlOpts
+): Promise<NextResponse> {
+  const auth = await requireV1Auth(request);
+  if ("error" in auth) return authErrorResponse(auth.error);
+  const { userId } = auth;
+
+  const rl = checkRateLimit(userId, rlOpts);
+  const headers = rateLimitHeaders(rl);
+  if (!rl.allowed) {
+    return apiError("RATE_LIMITED", "Rate limit exceeded.", {
+      retryAfter: rl.retryAfter,
+      headers,
+    });
+  }
+
+  try {
+    const key = request.headers.get("idempotency-key");
+    const { status, body } = await runIdempotent({
+      userId,
+      key,
+      route: routeLabel,
+      produce: () => produce({ userId, request }),
+    });
+    return ok(body, { status, headers });
+  } catch (error) {
+    return handleThrown(error, headers);
+  }
+}
+
+/**
+ * Wrap a v1 READ handler: auth → rate-limit → envelope (no idempotency).
+ */
+export async function v1Read(
+  request: NextRequest,
+  produce: (ctx: V1Context) => Promise<V1Result>,
+  rlOpts?: RlOpts
+): Promise<NextResponse> {
+  const auth = await requireV1Auth(request);
+  if ("error" in auth) return authErrorResponse(auth.error);
+  const { userId } = auth;
+
+  const rl = checkRateLimit(userId, rlOpts);
+  const headers = rateLimitHeaders(rl);
+  if (!rl.allowed) {
+    return apiError("RATE_LIMITED", "Rate limit exceeded.", {
+      retryAfter: rl.retryAfter,
+      headers,
+    });
+  }
+
+  try {
+    const { status, body } = await produce({ userId, request });
+    return ok(body, { status: status ?? 200, headers });
+  } catch (error) {
+    return handleThrown(error, headers);
+  }
+}

--- a/src/lib/auth/__tests__/api-key.test.ts
+++ b/src/lib/auth/__tests__/api-key.test.ts
@@ -1,0 +1,197 @@
+import { NextRequest } from "next/server";
+import { getToken } from "next-auth/jwt";
+
+import {
+  extractBearerKey,
+  generateApiKey,
+  hashKey,
+  parseKey,
+  requireV1Auth,
+  verifyApiKey,
+} from "@/lib/auth/api-key";
+import { prisma } from "@/lib/prisma";
+
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    apiKey: {
+      findUnique: jest.fn(),
+      update: jest.fn().mockResolvedValue({}),
+    },
+    apiSettings: {
+      findUnique: jest.fn(),
+    },
+  },
+}));
+
+jest.mock("@/lib/logger", () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn() },
+}));
+
+jest.mock("next-auth/jwt", () => ({ getToken: jest.fn() }));
+
+const mockApiKey = prisma.apiKey as unknown as {
+  findUnique: jest.Mock;
+  update: jest.Mock;
+};
+const mockApiSettings = prisma.apiSettings as unknown as {
+  findUnique: jest.Mock;
+};
+const mockGetToken = getToken as unknown as jest.Mock;
+
+function req(headers: Record<string, string>): NextRequest {
+  return { headers: new Headers(headers) } as unknown as NextRequest;
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("key generation + parsing", () => {
+  it("generates a well-formed fcal token and a matching hash", () => {
+    const { fullKey, keyPrefix, hashedKey } = generateApiKey();
+    expect(fullKey).toMatch(/^fcal_[0-9a-f]{16}_[A-Za-z0-9_-]+$/);
+    expect(fullKey.split("_")[1]).toBe(keyPrefix);
+    expect(hashedKey).toBe(hashKey(fullKey));
+    expect(hashedKey).toHaveLength(64); // sha256 hex
+  });
+
+  it("parses valid keys and rejects malformed ones", () => {
+    const { fullKey, keyPrefix } = generateApiKey();
+    expect(parseKey(fullKey)).toEqual({ keyPrefix });
+    expect(parseKey("nope")).toBeNull();
+    expect(parseKey("wrong_aaaa_bbbb")).toBeNull(); // bad product prefix
+    expect(parseKey("fcal__bbbb")).toBeNull(); // empty prefix
+  });
+
+  it("extracts only fcal bearer tokens", () => {
+    const { fullKey } = generateApiKey();
+    expect(extractBearerKey(req({ authorization: `Bearer ${fullKey}` }))).toBe(
+      fullKey
+    );
+    expect(extractBearerKey(req({ authorization: "Bearer xyz" }))).toBeNull();
+    expect(extractBearerKey(req({}))).toBeNull();
+  });
+});
+
+describe("verifyApiKey", () => {
+  it("accepts a valid, enabled key and stamps lastUsedAt", async () => {
+    const { fullKey, keyPrefix, hashedKey } = generateApiKey();
+    mockApiKey.findUnique.mockResolvedValue({
+      id: "k1",
+      userId: "u1",
+      hashedKey,
+      revokedAt: null,
+      expiresAt: null,
+    });
+    mockApiSettings.findUnique.mockResolvedValue({ enabled: true });
+
+    await expect(verifyApiKey(fullKey)).resolves.toEqual({ userId: "u1" });
+    expect(mockApiKey.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { keyPrefix } })
+    );
+    expect(mockApiKey.update).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "k1" } })
+    );
+  });
+
+  it("rejects an unknown prefix", async () => {
+    mockApiKey.findUnique.mockResolvedValue(null);
+    await expect(verifyApiKey(generateApiKey().fullKey)).resolves.toEqual({
+      error: "unauthorized",
+    });
+  });
+
+  it("rejects a revoked key", async () => {
+    const { fullKey, hashedKey } = generateApiKey();
+    mockApiKey.findUnique.mockResolvedValue({
+      id: "k1",
+      userId: "u1",
+      hashedKey,
+      revokedAt: new Date(),
+      expiresAt: null,
+    });
+    await expect(verifyApiKey(fullKey)).resolves.toEqual({
+      error: "unauthorized",
+    });
+    expect(mockApiSettings.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("rejects an expired key", async () => {
+    const { fullKey, hashedKey } = generateApiKey();
+    mockApiKey.findUnique.mockResolvedValue({
+      id: "k1",
+      userId: "u1",
+      hashedKey,
+      revokedAt: null,
+      expiresAt: new Date(Date.now() - 1000),
+    });
+    await expect(verifyApiKey(fullKey)).resolves.toEqual({
+      error: "unauthorized",
+    });
+  });
+
+  it("returns forbidden when the per-user gate is disabled", async () => {
+    const { fullKey, hashedKey } = generateApiKey();
+    mockApiKey.findUnique.mockResolvedValue({
+      id: "k1",
+      userId: "u1",
+      hashedKey,
+      revokedAt: null,
+      expiresAt: null,
+    });
+    mockApiSettings.findUnique.mockResolvedValue({ enabled: false });
+    await expect(verifyApiKey(fullKey)).resolves.toEqual({
+      error: "forbidden",
+    });
+    // Gate is checked before the hash compare (fail-fast) so update never fires.
+    expect(mockApiKey.update).not.toHaveBeenCalled();
+  });
+
+  it("rejects a tampered secret with a matching prefix (hash mismatch)", async () => {
+    const real = generateApiKey();
+    // Same prefix, different secret -> different full key -> hash won't match.
+    const forged = `fcal_${real.keyPrefix}_tamperedsecretvalue`;
+    mockApiKey.findUnique.mockResolvedValue({
+      id: "k1",
+      userId: "u1",
+      hashedKey: real.hashedKey,
+      revokedAt: null,
+      expiresAt: null,
+    });
+    mockApiSettings.findUnique.mockResolvedValue({ enabled: true });
+    await expect(verifyApiKey(forged)).resolves.toEqual({
+      error: "unauthorized",
+    });
+  });
+});
+
+describe("requireV1Auth", () => {
+  it("authenticates via a valid API key", async () => {
+    const { fullKey, hashedKey } = generateApiKey();
+    mockApiKey.findUnique.mockResolvedValue({
+      id: "k1",
+      userId: "u1",
+      hashedKey,
+      revokedAt: null,
+      expiresAt: null,
+    });
+    mockApiSettings.findUnique.mockResolvedValue({ enabled: true });
+    await expect(
+      requireV1Auth(req({ authorization: `Bearer ${fullKey}` }))
+    ).resolves.toEqual({ userId: "u1", authMethod: "api_key" });
+    expect(mockGetToken).not.toHaveBeenCalled();
+  });
+
+  it("falls back to a NextAuth session when no key is present", async () => {
+    mockGetToken.mockResolvedValue({ sub: "u2" });
+    await expect(requireV1Auth(req({}))).resolves.toEqual({
+      userId: "u2",
+      authMethod: "session",
+    });
+  });
+
+  it("returns unauthorized with neither key nor session", async () => {
+    mockGetToken.mockResolvedValue(null);
+    await expect(requireV1Auth(req({}))).resolves.toEqual({
+      error: "unauthorized",
+    });
+  });
+});

--- a/src/lib/auth/api-key.ts
+++ b/src/lib/auth/api-key.ts
@@ -1,0 +1,160 @@
+import { createHash, randomBytes, timingSafeEqual } from "crypto";
+
+import { getToken } from "next-auth/jwt";
+import { NextRequest } from "next/server";
+
+import { logger } from "@/lib/logger";
+import { prisma } from "@/lib/prisma";
+
+const LOG_SOURCE = "ApiKeyAuth";
+
+/**
+ * Programmatic API key auth for the /api/v1 surface (issue #160).
+ *
+ * Token shape: `fcal_<prefix>_<secret>`
+ *  - `prefix` is a public, indexed lookup id (safe to display in the UI).
+ *  - `secret` is high-entropy random; only the SHA-256 of the FULL token is stored.
+ *
+ * SHA-256 (not bcrypt) is correct here: keys are 256-bit random secrets, not
+ * low-entropy passwords, so there is nothing to brute-force and we want a fast,
+ * constant-time compare on the hot path.
+ */
+
+const KEY_PRODUCT_PREFIX = "fcal";
+const PREFIX_BYTES = 8; // 16 hex chars — indexed lookup id
+const SECRET_BYTES = 32; // 256-bit secret
+
+export type ApiKeyError = "unauthorized" | "forbidden";
+
+/** Generate a new key. The plaintext is returned ONCE and never stored. */
+export function generateApiKey(): {
+  fullKey: string;
+  keyPrefix: string;
+  hashedKey: string;
+} {
+  const keyPrefix = randomBytes(PREFIX_BYTES).toString("hex");
+  const secret = randomBytes(SECRET_BYTES).toString("base64url");
+  const fullKey = `${KEY_PRODUCT_PREFIX}_${keyPrefix}_${secret}`;
+  return { fullKey, keyPrefix, hashedKey: hashKey(fullKey) };
+}
+
+/** SHA-256 hex of the full token. */
+export function hashKey(fullKey: string): string {
+  return createHash("sha256").update(fullKey).digest("hex");
+}
+
+/** Parse a token into its prefix, or null if it isn't a well-formed fcal key. */
+export function parseKey(
+  fullKey: string
+): { keyPrefix: string } | null {
+  // Split on only the first two underscores: the prefix is hex (underscore-free)
+  // but the base64url secret may itself contain `_`, so a naive split over-splits.
+  const first = fullKey.indexOf("_");
+  const second = fullKey.indexOf("_", first + 1);
+  if (first === -1 || second === -1) return null;
+  const product = fullKey.slice(0, first);
+  const keyPrefix = fullKey.slice(first + 1, second);
+  const secret = fullKey.slice(second + 1);
+  if (product !== KEY_PRODUCT_PREFIX || !keyPrefix || !secret) return null;
+  return { keyPrefix };
+}
+
+/** Constant-time hex-string compare that never throws on length mismatch. */
+function safeHashEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  try {
+    return timingSafeEqual(Buffer.from(a, "hex"), Buffer.from(b, "hex"));
+  } catch {
+    return false;
+  }
+}
+
+/** Extract the `fcal_` bearer token from a request, or null if not present. */
+export function extractBearerKey(request: NextRequest): string | null {
+  const header = request.headers.get("authorization") ?? "";
+  if (!header.startsWith("Bearer ")) return null;
+  const token = header.slice(7).trim();
+  return token.startsWith(`${KEY_PRODUCT_PREFIX}_`) ? token : null;
+}
+
+/**
+ * Validate a full key and return the owning userId, or an error code.
+ * Order is deliberate (fail-fast, least work on bad input):
+ *   parse → prefix lookup → revoked/expired → enable-gate → constant-time hash.
+ * The full key is never logged.
+ */
+export async function verifyApiKey(
+  fullKey: string
+): Promise<{ userId: string } | { error: ApiKeyError }> {
+  const parsed = parseKey(fullKey);
+  if (!parsed) return { error: "unauthorized" };
+
+  const apiKey = await prisma.apiKey.findUnique({
+    where: { keyPrefix: parsed.keyPrefix },
+    select: {
+      id: true,
+      userId: true,
+      hashedKey: true,
+      revokedAt: true,
+      expiresAt: true,
+    },
+  });
+
+  if (!apiKey) return { error: "unauthorized" };
+  if (apiKey.revokedAt) return { error: "unauthorized" };
+  if (apiKey.expiresAt && apiKey.expiresAt.getTime() <= Date.now()) {
+    return { error: "unauthorized" };
+  }
+
+  // Per-user master gate (default-deny). Checked before the hash compare so a
+  // disabled account can't be used to burn CPU on hashing.
+  const settings = await prisma.apiSettings.findUnique({
+    where: { userId: apiKey.userId },
+    select: { enabled: true },
+  });
+  if (!settings?.enabled) return { error: "forbidden" };
+
+  if (!safeHashEqual(hashKey(fullKey), apiKey.hashedKey)) {
+    return { error: "unauthorized" };
+  }
+
+  // Fire-and-forget; never block the request on the audit write.
+  prisma.apiKey
+    .update({ where: { id: apiKey.id }, data: { lastUsedAt: new Date() } })
+    .catch((error) =>
+      logger.error(
+        "Failed to update apiKey.lastUsedAt",
+        { error: error instanceof Error ? error.message : "unknown" },
+        LOG_SOURCE
+      )
+    );
+
+  return { userId: apiKey.userId };
+}
+
+export type V1Auth =
+  | { userId: string; authMethod: "api_key" | "session" }
+  | { error: ApiKeyError };
+
+/**
+ * Authenticate an /api/v1 request via API key OR NextAuth session.
+ * Returns an error code (callers map to the v1 error envelope) rather than a
+ * NextResponse, so the envelope lives in one place (lib/api/respond).
+ */
+export async function requireV1Auth(request: NextRequest): Promise<V1Auth> {
+  const key = extractBearerKey(request);
+  if (key) {
+    const result = await verifyApiKey(key);
+    if ("error" in result) return result;
+    return { userId: result.userId, authMethod: "api_key" };
+  }
+
+  // Fall back to a logged-in browser session so the in-app docs/UI can call v1.
+  const token = await getToken({
+    req: request,
+    secret: process.env.NEXTAUTH_SECRET,
+  });
+  if (token?.sub) return { userId: token.sub, authMethod: "session" };
+
+  return { error: "unauthorized" };
+}


### PR DESCRIPTION
## Summary

Adds a versioned public REST API (`/api/v1`) so external tools — automation
platforms, meeting assistants, scripts, or a future first-party app — can create
tasks and events and let FluidCalendar's auto-scheduler position tasks.
Authenticated with opt-in, per-user API keys managed from **Settings → API & Developer**.

Closes #160.

## Feature set

**Endpoints (`/api/v1`)**
- `POST /tasks` — create one or a batch; optional `autoScheduled` runs the scheduler **once** for the batch and returns the booked `scheduledStart`/`scheduledEnd`
- `GET /tasks`, `GET|PATCH|DELETE /tasks/{id}`
- `POST /events` — create one or a batch; auto-resolves the user's local calendar (no feed id required)
- `GET /events`, `GET|PATCH|DELETE /events/{id}`
- `POST /schedule` — trigger a replan (rate-limited tighter than reads/writes)

**Key management (session-only — an API key cannot mint keys)**
- `GET|POST /api/api-keys`, `DELETE /api/api-keys/{id}`, `GET|PATCH /api/api-settings`
- UI: enable toggle, key list, create-once modal, revoke

**Docs:** `docs/api-reference.md`

## Auth & security model
- Keys are `fcal_<prefix>_<secret>`; only a SHA-256 hash is stored; constant-time compare; plaintext shown once
- Per-user enable gate (default-deny); revoke + optional expiry
- API-key auth lives **only** on `/api/v1`; internal routes stay session-only by construction, so a key can't reach admin/management/settings
- Multi-tenant: every query scoped to the authenticated user; explicit field allow-lists on writes (no mass-assignment); local-feed resolve is user-scoped
- Keys are bearer credentials — send over HTTPS only (run behind a TLS-terminating proxy)

## Standards & conventions (for future adaptation)
- **Dates:** strict RFC 3339 in, UTC storage, ISO-8601-`Z` out; loose/ambiguous inputs are rejected with 400
- **Recurrence:** iCalendar RRULE (RFC 5545)
- **Pagination:** cursor — `{ data, next_cursor, has_more }`, default 50 / max 500
- **Idempotency:** `Idempotency-Key` header replays the first 2xx response
- **Rate limits:** `X-RateLimit-*` + `Retry-After`
- **Errors:** `{ error: { code, message, field? } }`
- **Versioning:** URL path; `v1` stays stable

## Extending this (design notes)
- All handlers go through one wrapper (`src/lib/api/v1.ts` — `v1Write`/`v1Read`) that does auth → rate-limit → idempotency → envelope; new endpoints stay thin: validate → call a service → return `{ status, body }`, throwing `ApiHttpError` for errors
- New resources (projects, tags, settings) drop in as new `/api/v1/*` files without changing the contract
- Non-breaking roadmap: `/api/v1/sync` (incremental sync for an offline app), a mobile OAuth flow, per-key scopes, structured recurrence, OpenAPI

## Testing
- Unit specs for the key library, the v1 wrapper, the date parser, and every endpoint
- Migration validated against a fresh Postgres (applies clean, zero residual diff)
- Verified end-to-end against a live Postgres: auth (valid/disabled/revoked), cross-tenant isolation, local-feed resolve, idempotency replay, date rejection; plus a live server run confirming auto-scheduled tasks position themselves into work hours

## Migration
One additive migration (`ApiKey`, `ApiSettings`, `IdempotencyKey`) — no changes to existing tables.
