### PR TITLE
fix(google): use OAuth expiry_date as absolute expiry (fixes silent calendar-sync failure)

### DIFF
--- a/src/app/api/calendar/google/route.ts
+++ b/src/app/api/calendar/google/route.ts
@@ -110,7 +110,10 @@ export async function GET(request: NextRequest) {
         {
           accessToken: tokens.access_token!,
           refreshToken: tokens.refresh_token!,
-          expiresAt: newDate(Date.now() + (tokens.expiry_date || 3600 * 1000)),
+          // expiry_date is an absolute epoch-ms timestamp from google-auth-library,
+          // not a duration — adding Date.now() pushed expiry decades out, so the
+          // token was never refreshed and every later call 401'd.
+          expiresAt: newDate(tokens.expiry_date || Date.now() + 3600 * 1000),
         },
         userId ?? "unknown"
       );

--- a/src/app/api/calendar/google/route.ts
+++ b/src/app/api/calendar/google/route.ts
@@ -111,7 +111,7 @@ export async function GET(request: NextRequest) {
           accessToken: tokens.access_token!,
           refreshToken: tokens.refresh_token!,
           // expiry_date is an absolute epoch-ms timestamp from google-auth-library,
-          // not a duration — adding Date.now() pushed expiry decades out, so the
+          // not a duration. Adding Date.now() pushed expiry decades out, so the
           // token was never refreshed and every later call 401'd.
           expiresAt: newDate(tokens.expiry_date || Date.now() + 3600 * 1000),
         },

--- a/src/lib/token-manager.ts
+++ b/src/lib/token-manager.ts
@@ -65,8 +65,9 @@ export class TokenManager {
 
     try {
       const response = await oauth2Client.refreshAccessToken();
+      // expiry_date is an absolute epoch-ms timestamp, not a duration.
       const expiresAt = newDate(
-        Date.now() + (response.credentials.expiry_date || 3600 * 1000)
+        response.credentials.expiry_date || Date.now() + 3600 * 1000
       );
 
       // Update tokens in database


### PR DESCRIPTION
Closes #195
Closes #132

`tokens.expiry_date` from `google-auth-library` is an absolute epoch-millisecond timestamp, not a duration. Both the OAuth callback and the token-refresh path added `Date.now()` to it, pushing the stored Google token expiry roughly to the year 2082. The "needs refresh" check (`expiresAt - now < 5m`) then never fired, so an expired access token was reused indefinitely and every Google Calendar API call failed with `401 invalid_token` - scheduled task blocks silently never reached the calendar (they just got marked `blockDirty`).

This uses `expiry_date` directly as the absolute expiry in both spots:
- `src/app/api/calendar/google/route.ts`
- `src/lib/token-manager.ts`

Outlook already handled this correctly via `expires_in`, so it's unaffected.

### Why this also closes #132
#132 ("No available calendars found for Google connection") is the user-visible symptom of the same root cause: once the access token silently expired, `calendarList.list()` could not return calendars, so the connection appeared to have none. Fixing the expiry math restores calendar listing on connect/refresh.

If either reported scenario differs from this root cause, please feel free to reopen the corresponding issue with details and we'll take another look.

### Verification
Reproduced and verified on a live self-hosted instance:
- Before: stored expiry was in 2082; the stored access token returned `invalid_token`; pushes silently failed.
- After: a connected account refreshes correctly (stored expiry ~1 hour out instead of 2082), and scheduled task blocks push to Google Calendar (a real Google event id is recorded on the task).
