### PR TITLE
fix(scheduler): re-sync calendar blocks when the auto-scheduler moves a task

### DIFF
--- a/src/__tests__/reschedule-block-resync.test.ts
+++ b/src/__tests__/reschedule-block-resync.test.ts
@@ -1,0 +1,160 @@
+import { prisma } from "@/lib/prisma";
+import { SchedulingService } from "@/services/scheduling/SchedulingService";
+import { scheduleAllTasksForUser } from "@/services/scheduling/TaskSchedulingService";
+
+// Regression test for the reschedule push-sync gap: when the auto-scheduler
+// MOVES a task that already has a pushed calendar block, the block must be
+// flagged blockDirty so the caller's repushDirtyBlocks re-syncs the calendar
+// event. Without the flag, repushDirtyBlocks (which only matches blockDirty or
+// a not-yet-pushed schedule) skips it and the calendar event goes stale.
+
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    task: {
+      findMany: jest.fn(),
+      updateMany: jest.fn(),
+    },
+    autoScheduleSettings: {
+      findUnique: jest.fn(),
+    },
+  },
+}));
+
+jest.mock("@/services/scheduling/SchedulingService");
+
+jest.mock("@/lib/logger", () => ({
+  logger: {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+const mockPrisma = prisma as unknown as {
+  task: { findMany: jest.Mock; updateMany: jest.Mock };
+  autoScheduleSettings: { findUnique: jest.Mock };
+};
+const MockScheduling = SchedulingService as unknown as jest.Mock;
+
+const USER = "user-1";
+
+function task(over: Record<string, unknown>) {
+  return {
+    id: "t",
+    title: "T",
+    blockEventId: null,
+    scheduledStart: null,
+    scheduledEnd: null,
+    project: null,
+    tags: [],
+    status: "todo",
+    priority: null,
+    energyLevel: null,
+    preferredTime: null,
+    ...over,
+  };
+}
+
+/** Find the updateMany call that flags moved blocks dirty, if any. */
+function dirtyFlagCall() {
+  return mockPrisma.task.updateMany.mock.calls.find(
+    ([arg]) => arg?.data?.blockDirty === true
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockPrisma.autoScheduleSettings.findUnique.mockResolvedValue({ userId: USER });
+  mockPrisma.task.updateMany.mockResolvedValue({ count: 0 });
+});
+
+/**
+ * Wire up the three findMany calls scheduleAllTasksForUser makes (tasksToSchedule,
+ * lockedTasks, final fetch) plus the scheduler's returned post-replan tasks.
+ */
+function arrange(opts: {
+  before: ReturnType<typeof task>[];
+  after: ReturnType<typeof task>[];
+}) {
+  mockPrisma.task.findMany
+    .mockResolvedValueOnce(opts.before) // tasksToSchedule (pre-clear positions)
+    .mockResolvedValueOnce([]) // lockedTasks
+    .mockResolvedValueOnce(opts.after); // final fetch for return value
+  MockScheduling.mockImplementation(() => ({
+    scheduleMultipleTasks: jest.fn().mockResolvedValue(opts.after),
+  }));
+}
+
+describe("scheduleAllTasksForUser → block resync", () => {
+  const start1 = new Date("2026-06-22T09:00:00Z");
+  const end1 = new Date("2026-06-22T09:30:00Z");
+  const start2 = new Date("2026-06-22T14:00:00Z");
+  const end2 = new Date("2026-06-22T14:30:00Z");
+
+  it("flags a moved, already-pushed task as blockDirty", async () => {
+    arrange({
+      before: [
+        task({ id: "a", blockEventId: "evt-a", scheduledStart: start1, scheduledEnd: end1 }),
+      ],
+      after: [
+        task({ id: "a", blockEventId: "evt-a", scheduledStart: start2, scheduledEnd: end2 }),
+      ],
+    });
+
+    await scheduleAllTasksForUser(USER);
+
+    const call = dirtyFlagCall();
+    expect(call).toBeDefined();
+    expect(call![0].where.id.in).toEqual(["a"]);
+  });
+
+  it("does NOT flag a task that landed in the same slot", async () => {
+    arrange({
+      before: [
+        task({ id: "a", blockEventId: "evt-a", scheduledStart: start1, scheduledEnd: end1 }),
+      ],
+      after: [
+        task({ id: "a", blockEventId: "evt-a", scheduledStart: start1, scheduledEnd: end1 }),
+      ],
+    });
+
+    await scheduleAllTasksForUser(USER);
+
+    expect(dirtyFlagCall()).toBeUndefined();
+  });
+
+  it("does NOT flag a moved task that has no block yet (repush handles it)", async () => {
+    arrange({
+      before: [
+        task({ id: "a", blockEventId: null, scheduledStart: null, scheduledEnd: null }),
+      ],
+      after: [
+        task({ id: "a", blockEventId: null, scheduledStart: start2, scheduledEnd: end2 }),
+      ],
+    });
+
+    await scheduleAllTasksForUser(USER);
+
+    expect(dirtyFlagCall()).toBeUndefined();
+  });
+
+  it("flags only the moved task when others stay put", async () => {
+    arrange({
+      before: [
+        task({ id: "a", blockEventId: "evt-a", scheduledStart: start1, scheduledEnd: end1 }),
+        task({ id: "b", blockEventId: "evt-b", scheduledStart: start2, scheduledEnd: end2 }),
+      ],
+      after: [
+        task({ id: "a", blockEventId: "evt-a", scheduledStart: start2, scheduledEnd: end2 }),
+        task({ id: "b", blockEventId: "evt-b", scheduledStart: start2, scheduledEnd: end2 }),
+      ],
+    });
+
+    await scheduleAllTasksForUser(USER);
+
+    const call = dirtyFlagCall();
+    expect(call).toBeDefined();
+    expect(call![0].where.id.in).toEqual(["a"]);
+  });
+});

--- a/src/services/scheduling/TaskSchedulingService.ts
+++ b/src/services/scheduling/TaskSchedulingService.ts
@@ -174,11 +174,43 @@ export async function scheduleAllTasksForUser(
       },
     });
 
+    // Snapshot pre-replan positions so we can detect which already-pushed
+    // blocks actually moved.
+    const previousById = new Map(
+      tasksToSchedule.map((task) => [task.id, task])
+    );
+
     // Schedule all tasks
     const updatedTasks = await schedulingService.scheduleMultipleTasks(
       [...tasksToSchedule, ...lockedTasks],
       userId
     );
+
+    // A task whose auto-scheduled slot changed needs its pushed calendar block
+    // re-synced. scheduleMultipleTasks only writes scheduledStart/End; it never
+    // flags the block, so repushDirtyBlocks (which only matches blockDirty=true
+    // or a not-yet-pushed schedule) would otherwise skip a moved-but-already-
+    // pushed task and leave a stale event on the calendar. Flag only the tasks
+    // that have an existing block AND actually moved, so we don't churn the
+    // calendar API for unchanged slots.
+    const movedTaskIds = updatedTasks
+      .filter((task) => {
+        const previous = previousById.get(task.id);
+        if (!previous || !previous.blockEventId) return false;
+        return (
+          previous.scheduledStart?.getTime() !==
+            task.scheduledStart?.getTime() ||
+          previous.scheduledEnd?.getTime() !== task.scheduledEnd?.getTime()
+        );
+      })
+      .map((task) => task.id);
+
+    if (movedTaskIds.length > 0) {
+      await prisma.task.updateMany({
+        where: { id: { in: movedTaskIds }, userId },
+        data: { blockDirty: true },
+      });
+    }
 
     // Update the lastScheduled timestamp for all tasks
     await prisma.task.updateMany({


### PR DESCRIPTION
## Summary

Fixes #201.

When the bulk auto-scheduler re-plans and **moves** a task that already has a pushed Google Calendar block, the block was left at its old time. The in-app schedule and the calendar event disagreed until something else dirtied the block.

`SchedulingService.scheduleTask` writes the task's new `scheduledStart`/`scheduledEnd` but never sets `blockDirty`, and `repushDirtyBlocks` only re-pushes tasks that are `blockDirty` or scheduled-with-`blockEventId = null`. A moved-but-already-pushed task matched neither, so its event was never updated. (Manual edits and drag-and-drop already update correctly via `schedulePushTaskBlock`; only the bulk path was affected.)

## Change

`scheduleAllTasksForUser` snapshots each task's pre-replan position, and after scheduling marks `blockDirty = true` only for tasks that have an existing `blockEventId` **and** actually moved. The existing `repushDirtyBlocks` → `pushTaskBlock` → `updateExistingEvent` path then moves the event in place. Unchanged slots are deliberately left untouched to avoid needless Calendar API churn.

## Tests

Adds `reschedule-block-resync.test.ts`: flags a moved already-pushed task, ignores a same-slot re-plan, ignores a moved task with no block yet (covered by the existing repush path), and flags only the moved task in a mixed set.

Verified on a self-hosted instance: re-planning that shifts already-pushed tasks now updates the corresponding Google events in place (same event id, new time).
