### PR TITLE
fix(scheduler): honor buffer time between auto-scheduled items (#176)

### DIFF
--- a/src/__tests__/auto-schedule-buffer.test.ts
+++ b/src/__tests__/auto-schedule-buffer.test.ts
@@ -1,0 +1,104 @@
+import { prisma } from "@/lib/prisma";
+import { CalendarServiceImpl } from "@/services/scheduling/CalendarServiceImpl";
+import { TimeSlot } from "@/types/scheduling";
+
+// Regression test for issue #176 ("Auto Scheduling is putting tasks too close
+// together"): bufferMinutes must enforce a real gap between a candidate slot and
+// existing busy intervals, not merely prevent overlap. Buffer is applied by
+// padding the busy interval, so a slot that merely abuts a task/event now
+// conflicts unless it keeps bufferMinutes of clearance.
+
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    task: { findMany: jest.fn() },
+    calendarEvent: { findMany: jest.fn() },
+  },
+}));
+
+const mockPrisma = prisma as unknown as {
+  task: { findMany: jest.Mock };
+  calendarEvent: { findMany: jest.Mock };
+};
+
+const USER = "user-1";
+
+function slot(startISO: string, endISO: string): TimeSlot {
+  return {
+    start: new Date(startISO),
+    end: new Date(endISO),
+    score: 0,
+    conflicts: [],
+    energyLevel: null,
+    isWithinWorkHours: true,
+    hasBufferTime: false,
+  };
+}
+
+/** A scheduled task occupying 10:00–10:30. With buffer=15 it "owns" 09:45–10:45. */
+function arrangeScheduledTask() {
+  // getEvents() returns [] for an empty calendar list without touching prisma,
+  // so the only DB reads are the two task.findMany calls.
+  mockPrisma.task.findMany
+    .mockResolvedValueOnce([
+      {
+        id: "busy",
+        title: "Existing task",
+        scheduledStart: new Date("2026-06-22T10:00:00Z"),
+        scheduledEnd: new Date("2026-06-22T10:30:00Z"),
+      },
+    ]) // scheduledTasks
+    .mockResolvedValueOnce([]); // pushedBlockIds
+}
+
+async function conflictsFor(candidate: TimeSlot, bufferMinutes: number) {
+  const svc = new CalendarServiceImpl();
+  const results = await svc.findBatchConflicts(
+    [{ slot: candidate, taskId: "new" }],
+    [], // no calendars selected -> event check is a no-op
+    USER,
+    "new",
+    bufferMinutes
+  );
+  return results[0].conflicts;
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("findBatchConflicts buffer enforcement (#176)", () => {
+  it("rejects a slot that starts the instant the task ends (no buffer gap)", async () => {
+    arrangeScheduledTask();
+    const c = await conflictsFor(
+      slot("2026-06-22T10:30:00Z", "2026-06-22T11:00:00Z"),
+      15
+    );
+    expect(c).toHaveLength(1);
+    expect(c[0].type).toBe("task");
+  });
+
+  it("accepts a slot that keeps the full buffer after the task", async () => {
+    arrangeScheduledTask();
+    const c = await conflictsFor(
+      slot("2026-06-22T10:45:00Z", "2026-06-22T11:15:00Z"),
+      15
+    );
+    expect(c).toHaveLength(0);
+  });
+
+  it("rejects a slot that ends inside the pre-task buffer", async () => {
+    arrangeScheduledTask();
+    const c = await conflictsFor(
+      slot("2026-06-22T09:30:00Z", "2026-06-22T10:00:00Z"),
+      15
+    );
+    expect(c).toHaveLength(1);
+  });
+
+  it("preserves legacy behavior (back-to-back allowed) when buffer is 0", async () => {
+    arrangeScheduledTask();
+    const c = await conflictsFor(
+      slot("2026-06-22T10:30:00Z", "2026-06-22T11:00:00Z"),
+      0
+    );
+    expect(c).toHaveLength(0);
+  });
+});

--- a/src/services/scheduling/CalendarService.ts
+++ b/src/services/scheduling/CalendarService.ts
@@ -12,7 +12,8 @@ export interface CalendarService {
     slot: TimeSlot,
     selectedCalendarIds: string[],
     userId: string,
-    excludeTaskId?: string
+    excludeTaskId?: string,
+    bufferMinutes?: number
   ): Promise<Conflict[]>;
 
   getEvents(
@@ -26,6 +27,7 @@ export interface CalendarService {
     slots: { slot: TimeSlot; taskId: string }[],
     selectedCalendarIds: string[],
     userId: string,
-    excludeTaskId?: string
+    excludeTaskId?: string,
+    bufferMinutes?: number
   ): Promise<BatchConflictCheck[]>;
 }

--- a/src/services/scheduling/CalendarServiceImpl.ts
+++ b/src/services/scheduling/CalendarServiceImpl.ts
@@ -1,6 +1,6 @@
 import { CalendarEvent } from "@prisma/client";
 
-import { areIntervalsOverlapping } from "@/lib/date-utils";
+import { addMinutes, areIntervalsOverlapping } from "@/lib/date-utils";
 import { prisma } from "@/lib/prisma";
 
 import { Conflict, TimeSlot } from "@/types/scheduling";
@@ -68,7 +68,8 @@ export class CalendarServiceImpl implements CalendarService {
     slot: TimeSlot,
     selectedCalendarIds: string[],
     userId: string,
-    excludeTaskId?: string
+    excludeTaskId?: string,
+    bufferMinutes = 0
   ): Promise<Conflict[]> {
     const conflicts: Conflict[] = [];
 
@@ -83,7 +84,12 @@ export class CalendarServiceImpl implements CalendarService {
       if (
         areIntervalsOverlapping(
           { start: slot.start, end: slot.end },
-          { start: event.start, end: event.end }
+          // Pad the busy interval by the user's buffer so a candidate slot must
+          // keep a gap from each event rather than just avoid overlapping it.
+          {
+            start: addMinutes(event.start, -bufferMinutes),
+            end: addMinutes(event.end, bufferMinutes),
+          }
         )
       ) {
         conflicts.push({
@@ -118,7 +124,10 @@ export class CalendarServiceImpl implements CalendarService {
         task.scheduledEnd &&
         areIntervalsOverlapping(
           { start: slot.start, end: slot.end },
-          { start: task.scheduledStart, end: task.scheduledEnd }
+          {
+            start: addMinutes(task.scheduledStart, -bufferMinutes),
+            end: addMinutes(task.scheduledEnd, bufferMinutes),
+          }
         )
       ) {
         conflicts.push({
@@ -202,7 +211,8 @@ export class CalendarServiceImpl implements CalendarService {
     slots: { slot: TimeSlot; taskId: string }[],
     selectedCalendarIds: string[],
     userId: string,
-    excludeTaskId?: string
+    excludeTaskId?: string,
+    bufferMinutes = 0
   ): Promise<BatchConflictCheck[]> {
     // Safety check: if slots array is empty, return empty results
     if (!slots || slots.length === 0) {
@@ -268,7 +278,12 @@ export class CalendarServiceImpl implements CalendarService {
         if (
           areIntervalsOverlapping(
             { start: slot.start, end: slot.end },
-            { start: event.start, end: event.end }
+            // Pad the busy interval by the user's buffer so a candidate slot
+            // must keep a gap from each event, not merely avoid overlapping it.
+            {
+              start: addMinutes(event.start, -bufferMinutes),
+              end: addMinutes(event.end, bufferMinutes),
+            }
           )
         ) {
           conflicts.push({
@@ -293,7 +308,10 @@ export class CalendarServiceImpl implements CalendarService {
             task.scheduledEnd &&
             areIntervalsOverlapping(
               { start: slot.start, end: slot.end },
-              { start: task.scheduledStart, end: task.scheduledEnd }
+              {
+                start: addMinutes(task.scheduledStart, -bufferMinutes),
+                end: addMinutes(task.scheduledEnd, bufferMinutes),
+              }
             )
           ) {
             conflicts.push({

--- a/src/services/scheduling/TimeSlotManager.ts
+++ b/src/services/scheduling/TimeSlotManager.ts
@@ -226,6 +226,12 @@ export class TimeSlotManagerImpl implements TimeSlotManager {
   ): TimeSlot[] {
     const slots: TimeSlot[] = [];
     const MINIMUM_BUFFER_MINUTES = 15;
+    // Candidate task slots are generated on a fine granularity instead of being
+    // snapped to a coarse 30-minute grid. Task blocks are fluid work items, not
+    // meetings, so they don't need round start times; a fine step lets a task
+    // pack right after the previous one (or an odd-ending calendar event) at the
+    // configured buffer distance rather than rounding the gap up to the grid.
+    const SLOT_GRANULARITY_MINUTES = 5;
 
     // Convert start and end dates to local time zone
     const localStartDate = toZonedTime(startDate, this.timeZone);
@@ -261,9 +267,10 @@ export class TimeSlotManagerImpl implements TimeSlotManager {
       );
     }
 
-    localCurrentStart = roundDateUp(localCurrentStart);
-    localEndDate = roundDateUp(localEndDate);
-    // Generate slots advancing by task duration
+    localCurrentStart = roundDateUp(localCurrentStart, SLOT_GRANULARITY_MINUTES);
+    localEndDate = roundDateUp(localEndDate, SLOT_GRANULARITY_MINUTES);
+    // Advance by the fine granularity so candidate starts aren't locked to the
+    // task duration; the duration still defines each slot's length.
     while (localCurrentStart < localEndDate) {
       const slotEnd = addMinutes(localCurrentStart, duration);
       // localCurrentStart/slotEnd hold wall-clock values in the user's
@@ -279,7 +286,7 @@ export class TimeSlotManagerImpl implements TimeSlotManager {
       };
 
       slots.push(slot);
-      localCurrentStart = addMinutes(localCurrentStart, duration);
+      localCurrentStart = addMinutes(localCurrentStart, SLOT_GRANULARITY_MINUTES);
     }
 
     return slots;

--- a/src/services/scheduling/TimeSlotManager.ts
+++ b/src/services/scheduling/TimeSlotManager.ts
@@ -344,10 +344,20 @@ export class TimeSlotManagerImpl implements TimeSlotManager {
       return [];
     }
 
-    return this.calendarService.findConflicts(slot, selectedCalendars, userId);
+    return this.calendarService.findConflicts(
+      slot,
+      selectedCalendars,
+      userId,
+      undefined,
+      this.settings.bufferMinutes
+    );
   }
 
   private hasInMemoryConflict(slot: TimeSlot): boolean {
+    // Tasks scheduled earlier in this same run live only in memory (the DB
+    // schedules were cleared at the start of the replan), so the buffer must be
+    // enforced here too — otherwise back-to-back tasks slip through.
+    const bufferMinutes = this.settings.bufferMinutes;
     // Check all project tasks for conflicts
     for (const [, projectTasks] of this.slotScorer
       .getScheduledTasks()
@@ -356,7 +366,10 @@ export class TimeSlotManagerImpl implements TimeSlotManager {
         if (
           areIntervalsOverlapping(
             { start: slot.start, end: slot.end },
-            { start: projectTask.start, end: projectTask.end }
+            {
+              start: addMinutes(projectTask.start, -bufferMinutes),
+              end: addMinutes(projectTask.end, bufferMinutes),
+            }
           )
         ) {
           return true;
@@ -386,7 +399,8 @@ export class TimeSlotManagerImpl implements TimeSlotManager {
       slotsToCheck,
       selectedCalendars,
       task.userId || "",
-      task.id
+      task.id,
+      this.settings.bufferMinutes
     );
 
     // Process results and check for conflicts with in-memory scheduled tasks


### PR DESCRIPTION
## Summary

Fixes #176.

The configured **buffer time** between auto-scheduled items was not honored: tasks were placed back-to-back with each other and with calendar events, exactly as reported. There were two distinct causes, fixed here together:

1. **Buffer was never enforced.** `bufferMinutes` only set a cosmetic `hasBufferTime` flag feeding a weak scoring preference, which the "prefer earlier" bias overrode (see the standing TODO in `TimeSlotManager.applyBufferTimes`). Now the buffer is enforced where conflicts are detected: each busy interval (calendar event or scheduled task) is padded by `bufferMinutes` on both sides, so a candidate slot must keep that much clearance instead of merely avoiding overlap. Applied in all three conflict paths — `findBatchConflicts`, `findConflicts`, and the in-memory check (`hasInMemoryConflict`) used during a full re-plan. `bufferMinutes = 0` preserves the previous back-to-back behavior.

2. **Gaps rounded up to a 30-minute grid.** Candidate slots were snapped to `:00`/`:30` and advanced by the task duration, so even with the buffer enforced a 15-minute setting produced 30-minute gaps and tasks couldn't pack tightly after an odd-ending event. Task blocks are fluid work items, not meetings, so they don't need round start times — slot generation now uses a 5-minute granularity, making the gap honor the configured buffer literally.

## Tests

Adds `auto-schedule-buffer.test.ts` (buffer enforced as a real gap; back-to-back still allowed at `bufferMinutes = 0`); existing scheduling suites updated/passing.

Verified on a self-hosted instance with a 15-minute buffer: auto-scheduled tasks now sit 15 minutes apart (and 15 minutes clear of meetings) instead of wall-to-wall.
