### PR TITLE
fix(calendar): stop re-importing our own pushed task blocks from Google

### DIFF
--- a/src/app/api/calendar/google/route.ts
+++ b/src/app/api/calendar/google/route.ts
@@ -9,6 +9,10 @@ import { createAllDayDate, newDate, newDateFromYMD } from "@/lib/date-utils";
 import { createGoogleOAuthClient } from "@/lib/google";
 import { getGoogleCalendarClient } from "@/lib/google-calendar";
 import { prisma } from "@/lib/prisma";
+import {
+  getPushedBlockEventIds,
+  isOwnPushedBlock,
+} from "@/lib/task-block-push";
 import { TokenManager } from "@/lib/token-manager";
 
 const LOG_SOURCE = "GoogleCalendarAPI";
@@ -272,6 +276,11 @@ export async function POST(request: NextRequest) {
         }
       }
 
+      // Our own pushed task blocks get synced back by Google as events; skip
+      // re-importing them so a task block never renders twice. Pre-fetched here,
+      // outside the transaction.
+      const pushedBlockIds = await getPushedBlockEventIds(userId);
+
       await prisma.$transaction(async (tx) => {
         // Master events are prefetched before starting the transaction (to avoid network calls inside transaction)
         // `masterEvents` is available from the outer scope
@@ -279,6 +288,10 @@ export async function POST(request: NextRequest) {
 
         // Create or update master events
         for (const [eventId, masterEventData] of masterEvents) {
+          // Skip echoes of our own pushed task blocks
+          if (isOwnPushedBlock(eventId, pushedBlockIds)) {
+            continue;
+          }
           const existingMaster = await tx.calendarEvent.findFirst({
             where: {
               feedId: feed.id,
@@ -360,6 +373,11 @@ export async function POST(request: NextRequest) {
 
         // Create or update instances
         for (const event of events) {
+          // Skip echoes of our own pushed task blocks
+          if (isOwnPushedBlock(event.id, pushedBlockIds)) {
+            continue;
+          }
+
           const masterEvent = event.recurringEventId
             ? await tx.calendarEvent.findFirst({
                 where: {
@@ -527,6 +545,11 @@ export async function PUT(request: NextRequest) {
       }
     }
 
+    // Our own pushed task blocks get synced back by Google as events; skip
+    // re-importing them so a task block never renders twice. Pre-fetched here,
+    // outside the transactions below.
+    const pushedBlockIds = await getPushedBlockEventIds(userId);
+
     // Now perform database operations in transaction
     await prisma.$transaction(async (tx) => {
       console.log("Deleting existing events");
@@ -543,6 +566,12 @@ export async function PUT(request: NextRequest) {
         
         // Skip events without start time
         if (!event.start?.dateTime && !event.start?.date) continue;
+
+        // Skip echoes of our own pushed task blocks
+        if (isOwnPushedBlock(event.id, pushedBlockIds)) {
+          console.log("Skipping echo of pushed task block:", event.id);
+          continue;
+        }
 
         // Get recurrence rule from pre-fetched master events
         if (event.recurringEventId) {

--- a/src/lib/__tests__/pushed-block-echoes.test.ts
+++ b/src/lib/__tests__/pushed-block-echoes.test.ts
@@ -1,0 +1,92 @@
+import { prisma } from "@/lib/prisma";
+import {
+  getPushedBlockEventIds,
+  isOwnPushedBlock,
+} from "@/lib/task-block-push";
+
+// Pushed task blocks are events FluidCalendar creates on the user's Google
+// calendar; the feed sync re-imports them as "echoes". These helpers let the
+// import (and conflict detection) recognize and skip those echoes so a task
+// block never renders twice. See the dedupe-pushed-block-echoes fix.
+
+jest.mock("@/lib/google-calendar", () => ({
+  createGoogleEvent: jest.fn(),
+  updateGoogleEvent: jest.fn(),
+  deleteGoogleEvent: jest.fn(),
+}));
+
+jest.mock("@/lib/prisma", () => ({
+  prisma: { task: { findMany: jest.fn() } },
+}));
+
+jest.mock("@/lib/logger", () => ({
+  logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+const mockPrisma = prisma as unknown as {
+  task: { findMany: jest.Mock };
+};
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("getPushedBlockEventIds", () => {
+  it("returns the set of non-null blockEventIds for the user", async () => {
+    mockPrisma.task.findMany.mockResolvedValue([
+      { blockEventId: "evt-1" },
+      { blockEventId: "evt-2" },
+    ]);
+
+    const result = await getPushedBlockEventIds("user-1");
+
+    expect(result).toEqual(new Set(["evt-1", "evt-2"]));
+    expect(mockPrisma.task.findMany).toHaveBeenCalledWith({
+      where: { userId: "user-1", blockEventId: { not: null } },
+      select: { blockEventId: true },
+    });
+  });
+
+  it("returns an empty set when the user has no pushed blocks", async () => {
+    mockPrisma.task.findMany.mockResolvedValue([]);
+    expect(await getPushedBlockEventIds("user-1")).toEqual(new Set());
+  });
+
+  it("filters out any null blockEventId values", async () => {
+    mockPrisma.task.findMany.mockResolvedValue([
+      { blockEventId: "evt-1" },
+      { blockEventId: null },
+    ]);
+    expect(await getPushedBlockEventIds("user-1")).toEqual(new Set(["evt-1"]));
+  });
+
+  it("accepts an injected client (e.g. a transaction client)", async () => {
+    const txFindMany = jest.fn().mockResolvedValue([{ blockEventId: "tx-evt" }]);
+    const tx = { task: { findMany: txFindMany } } as never;
+
+    const result = await getPushedBlockEventIds("user-1", tx);
+
+    expect(result).toEqual(new Set(["tx-evt"]));
+    expect(txFindMany).toHaveBeenCalled();
+    expect(mockPrisma.task.findMany).not.toHaveBeenCalled();
+  });
+});
+
+describe("isOwnPushedBlock", () => {
+  const pushed = new Set(["evt-1", "evt-2"]);
+
+  it("is true when the event id is a pushed block", () => {
+    expect(isOwnPushedBlock("evt-1", pushed)).toBe(true);
+  });
+
+  it("is false when the event id is not a pushed block", () => {
+    expect(isOwnPushedBlock("evt-9", pushed)).toBe(false);
+  });
+
+  it("is false for null/undefined event ids", () => {
+    expect(isOwnPushedBlock(null, pushed)).toBe(false);
+    expect(isOwnPushedBlock(undefined, pushed)).toBe(false);
+  });
+
+  it("is false against an empty pushed set", () => {
+    expect(isOwnPushedBlock("evt-1", new Set())).toBe(false);
+  });
+});

--- a/src/lib/task-block-push.ts
+++ b/src/lib/task-block-push.ts
@@ -655,3 +655,37 @@ export async function repushDirtyBlocks(userId: string) {
     );
   }
 }
+
+/**
+ * Returns the set of Google event ids that are this user's pushed task blocks.
+ *
+ * These are events FluidCalendar created on the user's Google calendar; the
+ * Google feed sync re-imports them, so any path that consumes feed events (sync
+ * import, conflict detection, display) must be able to recognize and skip them.
+ * Pre-fetch this OUTSIDE a transaction to avoid a query inside the DB write loop.
+ */
+export async function getPushedBlockEventIds(
+  userId: string,
+  client = prisma
+): Promise<Set<string>> {
+  const tasks = await client.task.findMany({
+    where: { userId, blockEventId: { not: null } },
+    select: { blockEventId: true },
+  });
+  return new Set(
+    tasks.map((t) => t.blockEventId).filter(Boolean) as string[]
+  );
+}
+
+/**
+ * True when a fetched Google event is an echo of one of our own pushed task
+ * blocks (matched by event id). Such echoes must not be persisted as
+ * CalendarEvents — the task already represents that time, and importing it would
+ * render the block twice in the calendar.
+ */
+export function isOwnPushedBlock(
+  eventId: string | null | undefined,
+  pushedBlockIds: Set<string>
+): boolean {
+  return !!eventId && pushedBlockIds.has(eventId);
+}

--- a/src/services/scheduling/CalendarServiceImpl.ts
+++ b/src/services/scheduling/CalendarServiceImpl.ts
@@ -2,6 +2,7 @@ import { CalendarEvent } from "@prisma/client";
 
 import { areIntervalsOverlapping } from "@/lib/date-utils";
 import { prisma } from "@/lib/prisma";
+import { getPushedBlockEventIds } from "@/lib/task-block-push";
 
 import { Conflict, TimeSlot } from "@/types/scheduling";
 
@@ -240,15 +241,9 @@ export class CalendarServiceImpl implements CalendarService {
     // Events that are projections of our own pushed task blocks must not
     // count as conflicts: the task side already owns that time via the
     // scheduled-task check, and a feed sync of the push target would
-    // otherwise make every scheduled task block its own slot.
-    const pushedBlockIds = new Set(
-      (
-        await prisma.task.findMany({
-          where: { userId, blockEventId: { not: null } },
-          select: { blockEventId: true },
-        })
-      ).map((t) => t.blockEventId)
-    );
+    // otherwise make every scheduled task block its own slot. (Echoes are also
+    // skipped at import now; this stays as defense-in-depth.)
+    const pushedBlockIds = await getPushedBlockEventIds(userId);
 
     // Check conflicts for each slot
     return slots.map(({ slot, taskId }) => {


### PR DESCRIPTION
## Summary

Fixes #202.

With "push task blocks to calendar" enabled, every pushed task was displayed **twice**: once as the task block, once as a calendar event. FluidCalendar pushes a block to Google (id stored on `Task.blockEventId`), and the Google feed sync then re-imports that same event into `CalendarEvent` as an "echo"; the calendar view renders task blocks and feed events together, so the task appears twice. Google Calendar itself shows it once.

## Change

Skip these echoes at the import boundary: when syncing a Google feed, don't persist an event whose id is one of the user's pushed `blockEventId`s. A new shared helper `getPushedBlockEventIds` is the single source of truth, used by both Google import handlers (initial connect + re-sync) and the scheduler's existing conflict-side skip (kept as defense-in-depth, now DRY).

Because Google re-sync is wipe-and-replace, existing echoes self-clean on the next sync — no migration, no schema change, no display-layer change. Removing the echo at the source de-duplicates display, conflict detection, and any other `CalendarEvent` consumer at once.

## Tests

Adds `pushed-block-echoes.test.ts` for the helper (`getPushedBlockEventIds`) and the skip predicate (`isOwnPushedBlock`).

Verified on a self-hosted instance: after the fix a Google sync no longer re-imports pushed blocks (echo rows drop to zero) and each task renders once, while the real Google event is untouched.
