### PR TITLE
fix(scheduler): completed tasks should not block their scheduled slot

### DIFF
--- a/src/services/scheduling/CalendarServiceImpl.ts
+++ b/src/services/scheduling/CalendarServiceImpl.ts
@@ -4,6 +4,7 @@ import { areIntervalsOverlapping } from "@/lib/date-utils";
 import { prisma } from "@/lib/prisma";
 
 import { Conflict, TimeSlot } from "@/types/scheduling";
+import { TaskStatus } from "@/types/task";
 
 import { BatchConflictCheck, CalendarService } from "./CalendarService";
 
@@ -107,6 +108,10 @@ export class CalendarServiceImpl implements CalendarService {
         isAutoScheduled: true,
         scheduledStart: { not: null },
         scheduledEnd: { not: null },
+        // A completed task's time is free: it must NOT block the slot it used to
+        // occupy, otherwise checking a task off can't compact the remaining
+        // tasks forward into the vacated time (they'd see it as still busy).
+        status: { not: TaskStatus.COMPLETED },
         id: excludeTaskId ? { not: excludeTaskId } : undefined,
         userId,
       },
@@ -232,6 +237,10 @@ export class CalendarServiceImpl implements CalendarService {
         isAutoScheduled: true,
         scheduledStart: { not: null },
         scheduledEnd: { not: null },
+        // A completed task's time is free: it must NOT block the slot it used to
+        // occupy, otherwise checking a task off can't compact the remaining
+        // tasks forward into the vacated time (they'd see it as still busy).
+        status: { not: TaskStatus.COMPLETED },
         id: excludeTaskId ? { not: excludeTaskId } : undefined,
         userId,
       },

--- a/src/services/scheduling/__tests__/completed-tasks-free-slot.test.ts
+++ b/src/services/scheduling/__tests__/completed-tasks-free-slot.test.ts
@@ -1,0 +1,63 @@
+import { prisma } from "@/lib/prisma";
+
+import { TimeSlot } from "@/types/scheduling";
+import { TaskStatus } from "@/types/task";
+
+import { CalendarServiceImpl } from "../CalendarServiceImpl";
+
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    task: { findMany: jest.fn() },
+    calendarEvent: { findMany: jest.fn() },
+  },
+}));
+
+const mockTaskFind = prisma.task.findMany as unknown as jest.Mock;
+const mockEventFind = prisma.calendarEvent.findMany as unknown as jest.Mock;
+
+const slot = {
+  start: new Date(2026, 5, 24, 10, 0, 0),
+  end: new Date(2026, 5, 24, 10, 30, 0),
+} as TimeSlot;
+
+/**
+ * A completed task keeps its scheduledStart/End (so it can still be displayed),
+ * but its time is free. The conflict queries must therefore exclude completed
+ * tasks — otherwise checking a task off can't compact the remaining tasks into
+ * the slot it vacated (they'd still see it as busy).
+ */
+describe("CalendarServiceImpl — completed tasks do not block their slot", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockEventFind.mockResolvedValue([]); // no calendar events
+    mockTaskFind.mockResolvedValue([]); // no busy tasks returned
+  });
+
+  it("findBatchConflicts excludes completed tasks from the busy-task query", async () => {
+    await new CalendarServiceImpl().findBatchConflicts(
+      [{ slot, taskId: "t1" }],
+      ["cal1"],
+      "u1"
+    );
+
+    expect(mockTaskFind).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          status: { not: TaskStatus.COMPLETED },
+        }),
+      })
+    );
+  });
+
+  it("findConflicts excludes completed tasks from the busy-task query", async () => {
+    await new CalendarServiceImpl().findConflicts(slot, ["cal1"], "u1");
+
+    expect(mockTaskFind).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          status: { not: TaskStatus.COMPLETED },
+        }),
+      })
+    );
+  });
+});


### PR DESCRIPTION
Auto-scheduled tasks keep their `scheduledStart/End` after completion (so they can still render), but the conflict queries in `CalendarServiceImpl` still treat them as busy — so checking a task off doesn't free its slot and the remaining tasks can't compact into the vacated time on the next re-plan.

This excludes `status: COMPLETED` from `findConflicts`/`findBatchConflicts`, so a completed task's time is available again. Tests added.

---
_Draft: verifying reflow on a live install before marking ready._