### PR TITLE
feat(calendar): hide completed tasks by default with a Show-completed toggle

### DIFF
--- a/src/__tests__/calendar-completed-tasks.test.ts
+++ b/src/__tests__/calendar-completed-tasks.test.ts
@@ -1,0 +1,103 @@
+import { useCalendarStore } from "@/store/calendar";
+import { useTaskStore } from "@/store/task";
+
+import { TaskStatus } from "@/types/task";
+
+/**
+ * Completed auto-scheduled tasks should stay on the calendar (drawn dimmed),
+ * rather than vanishing, so the day reflects what was actually done. Completed
+ * tasks WITHOUT a scheduled slot stay hidden so views aren't flooded.
+ */
+
+// A 9am–9:30am slot "today" and the day window around it.
+const dayStart = new Date(2026, 5, 23, 0, 0, 0, 0);
+const dayEnd = new Date(2026, 5, 23, 23, 59, 59, 999);
+const slotStart = new Date(2026, 5, 23, 9, 0, 0, 0);
+const slotEnd = new Date(2026, 5, 23, 9, 30, 0, 0);
+
+function task(overrides: Record<string, unknown>) {
+  return {
+    id: "t",
+    title: "Task",
+    description: null,
+    status: TaskStatus.TODO,
+    isAutoScheduled: false,
+    scheduledStart: null,
+    scheduledEnd: null,
+    dueDate: null,
+    isRecurring: false,
+    tags: [],
+    priority: null,
+    energyLevel: null,
+    preferredTime: null,
+    ...overrides,
+  };
+}
+
+function eventsForDay() {
+  return useCalendarStore.getState().getTasksAsEvents(dayStart, dayEnd);
+}
+
+describe("getTasksAsEvents — completed tasks", () => {
+  afterEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    useTaskStore.setState({ tasks: [] } as any);
+  });
+
+  it("keeps a completed auto-scheduled task at its slot (so it can render dimmed)", () => {
+    useTaskStore.setState({
+      tasks: [
+        task({
+          id: "done",
+          status: TaskStatus.COMPLETED,
+          isAutoScheduled: true,
+          scheduledStart: slotStart,
+          scheduledEnd: slotEnd,
+        }),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ] as any,
+    });
+
+    const events = eventsForDay();
+    const done = events.find((e) => e.extendedProps?.taskId === "done");
+    expect(done).toBeDefined();
+    expect(done?.extendedProps?.status).toBe(TaskStatus.COMPLETED);
+  });
+
+  it("still shows an incomplete auto-scheduled task at its slot", () => {
+    useTaskStore.setState({
+      tasks: [
+        task({
+          id: "todo",
+          status: TaskStatus.TODO,
+          isAutoScheduled: true,
+          scheduledStart: slotStart,
+          scheduledEnd: slotEnd,
+        }),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ] as any,
+    });
+
+    expect(
+      eventsForDay().some((e) => e.extendedProps?.taskId === "todo")
+    ).toBe(true);
+  });
+
+  it("hides a completed task that has no scheduled slot (only a due date)", () => {
+    useTaskStore.setState({
+      tasks: [
+        task({
+          id: "done-unscheduled",
+          status: TaskStatus.COMPLETED,
+          isAutoScheduled: false,
+          dueDate: slotStart,
+        }),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ] as any,
+    });
+
+    expect(
+      eventsForDay().some((e) => e.extendedProps?.taskId === "done-unscheduled")
+    ).toBe(false);
+  });
+});

--- a/src/__tests__/calendar-completed-tasks.test.ts
+++ b/src/__tests__/calendar-completed-tasks.test.ts
@@ -1,12 +1,14 @@
 import { useCalendarStore } from "@/store/calendar";
+import { useCalendarViewSettings } from "@/store/calendarViewSettings";
 import { useTaskStore } from "@/store/task";
 
 import { TaskStatus } from "@/types/task";
 
 /**
- * Completed auto-scheduled tasks should stay on the calendar (drawn dimmed),
- * rather than vanishing, so the day reflects what was actually done. Completed
- * tasks WITHOUT a scheduled slot stay hidden so views aren't flooded.
+ * Completed auto-scheduled tasks are hidden from the calendar by default
+ * (Motion-style) so finishing one visibly frees its slot. The "Show completed"
+ * toggle brings them back, drawn dimmed. Completed tasks WITHOUT a scheduled
+ * slot stay hidden either way so views aren't flooded.
  */
 
 // A 9am–9:30am slot "today" and the day window around it.
@@ -39,12 +41,36 @@ function eventsForDay() {
 }
 
 describe("getTasksAsEvents — completed tasks", () => {
+  beforeEach(() => {
+    useCalendarViewSettings.setState({ showCompletedTasks: false });
+  });
   afterEach(() => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     useTaskStore.setState({ tasks: [] } as any);
+    useCalendarViewSettings.setState({ showCompletedTasks: false });
   });
 
-  it("keeps a completed auto-scheduled task at its slot (so it can render dimmed)", () => {
+  it("hides a completed auto-scheduled task by default (frees its slot)", () => {
+    useTaskStore.setState({
+      tasks: [
+        task({
+          id: "done-default",
+          status: TaskStatus.COMPLETED,
+          isAutoScheduled: true,
+          scheduledStart: slotStart,
+          scheduledEnd: slotEnd,
+        }),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ] as any,
+    });
+
+    expect(
+      eventsForDay().some((e) => e.extendedProps?.taskId === "done-default")
+    ).toBe(false);
+  });
+
+  it("shows a completed auto-scheduled task when the toggle is on (dimmed)", () => {
+    useCalendarViewSettings.setState({ showCompletedTasks: true });
     useTaskStore.setState({
       tasks: [
         task({

--- a/src/components/calendar/Calendar.tsx
+++ b/src/components/calendar/Calendar.tsx
@@ -4,7 +4,11 @@ import { useEffect } from "react";
 
 import dynamic from "next/dynamic";
 import { HiMenu } from "react-icons/hi";
-import { IoChevronBack, IoChevronForward } from "react-icons/io5";
+import {
+  IoCheckmarkCircleOutline,
+  IoChevronBack,
+  IoChevronForward,
+} from "react-icons/io5";
 
 import { DayView } from "@/components/calendar/DayView";
 import { FeedManager } from "@/components/calendar/FeedManager";
@@ -22,6 +26,7 @@ import {
   useCalendarUIStore,
   useViewStore,
 } from "@/store/calendar";
+import { useCalendarViewSettings } from "@/store/calendarViewSettings";
 import { useTaskStore } from "@/store/task";
 
 import { CalendarEvent, CalendarFeed } from "@/types/calendar";
@@ -45,6 +50,8 @@ export function Calendar({
 }: CalendarProps) {
   const { date: currentDate, setDate, view, setView } = useViewStore();
   const { isSidebarOpen, setSidebarOpen, isHydrated } = useCalendarUIStore();
+  const { showCompletedTasks, toggleShowCompletedTasks } =
+    useCalendarViewSettings();
   const { scheduleAllTasks } = useTaskStore();
   const { setFeeds, setEvents } = useCalendarStore();
 
@@ -172,6 +179,23 @@ export function Calendar({
 
           {/* View Switching Buttons */}
           <div className="ml-auto flex items-center gap-2">
+            <button
+              onClick={toggleShowCompletedTasks}
+              className={cn(
+                "flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm font-medium",
+                showCompletedTasks
+                  ? "bg-primary/10 text-primary"
+                  : "text-muted-foreground hover:bg-muted hover:text-foreground"
+              )}
+              title={
+                showCompletedTasks
+                  ? "Hide completed tasks"
+                  : "Show completed tasks"
+              }
+            >
+              <IoCheckmarkCircleOutline className="h-4 w-4" />
+              Completed
+            </button>
             <button
               onClick={() => setView("day")}
               className={cn(

--- a/src/components/calendar/DayView.tsx
+++ b/src/components/calendar/DayView.tsx
@@ -18,6 +18,7 @@ import { useEventModalStore } from "@/lib/commands/groups/calendar";
 import { newDate } from "@/lib/date-utils";
 
 import { useCalendarStore } from "@/store/calendar";
+import { useCalendarViewSettings } from "@/store/calendarViewSettings";
 import { useSettingsStore } from "@/store/settings";
 import { useTaskStore } from "@/store/task";
 
@@ -63,6 +64,9 @@ export function DayView({ currentDate, onDateClick }: DayViewProps) {
   >([]);
   const calendarRef = useRef<FullCalendar>(null);
   const tasks = useTaskStore((state) => state.tasks);
+  const showCompletedTasks = useCalendarViewSettings(
+    (state) => state.showCompletedTasks
+  );
   const [quickViewItem, setQuickViewItem] = useState<CalendarEvent | Task>();
   const [isTask, setIsTask] = useState(false);
   const eventModalStore = useEventModalStore();
@@ -141,7 +145,7 @@ export function DayView({ currentDate, onDateClick }: DayViewProps) {
         view: calendar.view,
       });
     }
-  }, [isLoading, feeds, userSettings.timeZone, handleDatesSet, tasks]);
+  }, [isLoading, feeds, userSettings.timeZone, handleDatesSet, tasks, showCompletedTasks]);
 
   // Update calendar date when currentDate changes
   useEffect(() => {

--- a/src/components/calendar/MonthView.tsx
+++ b/src/components/calendar/MonthView.tsx
@@ -18,6 +18,7 @@ import { useEventModalStore } from "@/lib/commands/groups/calendar";
 import { newDate } from "@/lib/date-utils";
 
 import { useCalendarStore } from "@/store/calendar";
+import { useCalendarViewSettings } from "@/store/calendarViewSettings";
 import { useSettingsStore } from "@/store/settings";
 import { useTaskStore } from "@/store/task";
 
@@ -63,6 +64,9 @@ export function MonthView({ currentDate, onDateClick }: MonthViewProps) {
   >([]);
   const calendarRef = useRef<FullCalendar>(null);
   const tasks = useTaskStore((state) => state.tasks);
+  const showCompletedTasks = useCalendarViewSettings(
+    (state) => state.showCompletedTasks
+  );
   const [quickViewItem, setQuickViewItem] = useState<CalendarEvent | Task>();
   const [isTask, setIsTask] = useState(false);
   const eventModalStore = useEventModalStore();
@@ -138,7 +142,7 @@ export function MonthView({ currentDate, onDateClick }: MonthViewProps) {
         view: calendar.view,
       });
     }
-  }, [isLoading, feeds, userSettings.timeZone, handleDatesSet, tasks]);
+  }, [isLoading, feeds, userSettings.timeZone, handleDatesSet, tasks, showCompletedTasks]);
 
   // Update calendar date when currentDate changes
   useEffect(() => {

--- a/src/components/calendar/MultiMonthView.tsx
+++ b/src/components/calendar/MultiMonthView.tsx
@@ -17,6 +17,7 @@ import { useEventModalStore } from "@/lib/commands/groups/calendar";
 import { newDate } from "@/lib/date-utils";
 
 import { useCalendarStore } from "@/store/calendar";
+import { useCalendarViewSettings } from "@/store/calendarViewSettings";
 import { useSettingsStore } from "@/store/settings";
 import { useTaskStore } from "@/store/task";
 
@@ -62,6 +63,9 @@ export function MultiMonthView({
   >([]);
   const calendarRef = useRef<FullCalendar>(null);
   const tasks = useTaskStore((state) => state.tasks);
+  const showCompletedTasks = useCalendarViewSettings(
+    (state) => state.showCompletedTasks
+  );
   const [quickViewItem, setQuickViewItem] = useState<CalendarEvent | Task>();
   const [isTask, setIsTask] = useState(false);
   const eventModalStore = useEventModalStore();
@@ -133,7 +137,7 @@ export function MultiMonthView({
         view: calendar.view,
       });
     }
-  }, [isLoading, feeds, userSettings.timeZone, handleDatesSet, tasks]);
+  }, [isLoading, feeds, userSettings.timeZone, handleDatesSet, tasks, showCompletedTasks]);
 
   // Update calendar date when currentDate changes
   useEffect(() => {

--- a/src/components/calendar/WeekView.tsx
+++ b/src/components/calendar/WeekView.tsx
@@ -18,6 +18,7 @@ import { useEventModalStore } from "@/lib/commands/groups/calendar";
 import { newDate } from "@/lib/date-utils";
 
 import { useCalendarStore } from "@/store/calendar";
+import { useCalendarViewSettings } from "@/store/calendarViewSettings";
 import { useSettingsStore } from "@/store/settings";
 import { useTaskStore } from "@/store/task";
 
@@ -63,6 +64,9 @@ export function WeekView({ currentDate, onDateClick }: WeekViewProps) {
   >([]);
   const calendarRef = useRef<FullCalendar>(null);
   const tasks = useTaskStore((state) => state.tasks);
+  const showCompletedTasks = useCalendarViewSettings(
+    (state) => state.showCompletedTasks
+  );
   const [quickViewItem, setQuickViewItem] = useState<CalendarEvent | Task>();
   const [isTask, setIsTask] = useState(false);
   const eventModalStore = useEventModalStore();
@@ -144,7 +148,7 @@ export function WeekView({ currentDate, onDateClick }: WeekViewProps) {
         view: calendar.view,
       });
     }
-  }, [isLoading, feeds, userSettings.timeZone, handleDatesSet, tasks]);
+  }, [isLoading, feeds, userSettings.timeZone, handleDatesSet, tasks, showCompletedTasks]);
 
   // Update calendar date when currentDate changes
   useEffect(() => {

--- a/src/store/calendar.ts
+++ b/src/store/calendar.ts
@@ -819,17 +819,23 @@ export const useCalendarStore = create<CalendarStore>()((set, get) => ({
 
     const events = tasks
       .filter((task) => {
-        // Skip completed tasks
+        if (task.isAutoScheduled && task.scheduledStart && task.scheduledEnd) {
+          // Auto-scheduled tasks render at their slot, INCLUDING completed ones:
+          // a completed task keeps its scheduledStart/End, so it stays put on the
+          // day you did it and is drawn dimmed/struck-through (see
+          // CalendarEventContent) rather than vanishing. Only its scheduled time
+          // needs to fall within the visible range.
+          const scheduledStart = newDate(task.scheduledStart);
+          return scheduledStart >= startDay && scheduledStart <= endDay;
+        }
+
+        // Non-auto-scheduled tasks: hide once completed so the calendar (esp.
+        // month view) isn't flooded with every finished to-do; otherwise place
+        // them on their due date.
         if (task.status === TaskStatus.COMPLETED) {
           return false;
         }
-
-        if (task.isAutoScheduled && task.scheduledStart && task.scheduledEnd) {
-          // For auto-scheduled tasks, check if scheduled time is within range
-          const scheduledStart = newDate(task.scheduledStart);
-          return scheduledStart >= startDay && scheduledStart <= endDay;
-        } else if (task.dueDate) {
-          // For non-auto-scheduled tasks, use due date logic
+        if (task.dueDate) {
           const taskDueDate = newDate(task.dueDate);
           const localDate = newDate(taskDueDate);
           localDate.setMinutes(

--- a/src/store/calendar.ts
+++ b/src/store/calendar.ts
@@ -6,6 +6,7 @@ import { persist } from "zustand/middleware";
 import { newDate, normalizeAllDayDate } from "@/lib/date-utils";
 import { DEFAULT_TASK_COLOR } from "@/lib/task-utils";
 
+import { useCalendarViewSettings } from "@/store/calendarViewSettings";
 import { useTaskStore } from "@/store/task";
 
 import {
@@ -809,6 +810,8 @@ export const useCalendarStore = create<CalendarStore>()((set, get) => ({
   // Convert tasks to calendar events
   getTasksAsEvents: (start: Date, end: Date) => {
     const tasks = useTaskStore.getState().tasks;
+    const showCompletedTasks =
+      useCalendarViewSettings.getState().showCompletedTasks;
     // const userTimeZone = useSettingsStore.getState().user.timeZone;
 
     // Create date boundaries in user's timezone
@@ -820,11 +823,13 @@ export const useCalendarStore = create<CalendarStore>()((set, get) => ({
     const events = tasks
       .filter((task) => {
         if (task.isAutoScheduled && task.scheduledStart && task.scheduledEnd) {
-          // Auto-scheduled tasks render at their slot, INCLUDING completed ones:
-          // a completed task keeps its scheduledStart/End, so it stays put on the
-          // day you did it and is drawn dimmed/struck-through (see
-          // CalendarEventContent) rather than vanishing. Only its scheduled time
-          // needs to fall within the visible range.
+          // A completed task keeps its scheduledStart/End, but its time has been
+          // freed for the re-plan. Hide it by default (Motion-style) so finishing
+          // one visibly opens its slot; the "Show completed" toggle brings it
+          // back, drawn dimmed/struck-through (see CalendarEventContent).
+          if (task.status === TaskStatus.COMPLETED && !showCompletedTasks) {
+            return false;
+          }
           const scheduledStart = newDate(task.scheduledStart);
           return scheduledStart >= startDay && scheduledStart <= endDay;
         }

--- a/src/store/calendarViewSettings.ts
+++ b/src/store/calendarViewSettings.ts
@@ -1,0 +1,30 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+/**
+ * Per-browser calendar view preferences (not synced to the server).
+ *
+ * `showCompletedTasks` mirrors Motion's "Show completed" toggle: completed
+ * auto-scheduled tasks are hidden from the calendar by default so finishing one
+ * visibly frees its slot and the remaining tasks compact upward. Flip it on to
+ * review what you did — completed tasks then render dimmed at their slots.
+ */
+interface CalendarViewSettings {
+  showCompletedTasks: boolean;
+  setShowCompletedTasks: (show: boolean) => void;
+  toggleShowCompletedTasks: () => void;
+}
+
+export const useCalendarViewSettings = create<CalendarViewSettings>()(
+  persist(
+    (set) => ({
+      showCompletedTasks: false,
+      setShowCompletedTasks: (showCompletedTasks) => set({ showCompletedTasks }),
+      toggleShowCompletedTasks: () =>
+        set((state) => ({ showCompletedTasks: !state.showCompletedTasks })),
+    }),
+    {
+      name: "calendar-view-settings",
+    }
+  )
+);


### PR DESCRIPTION
Mirrors Motion: completing an auto-scheduled task gets it out of the way so the day visibly frees up, with a header **"Completed"** toggle to review what you did (drawn dimmed).

- Completed auto-scheduled tasks are hidden from the grid by default.
- A "Completed" toggle in the calendar header reveals them, drawn dimmed.
- New per-browser `calendarViewSettings` store (persisted); applies across Day/Week/Month/Year.

Pairs with #209 (the scheduler fix) for the full reflow behavior, but is independent. Tests added.

---
_Draft: pending UI sign-off._