### PR TITLE
feat(scheduler): internal cron endpoint for periodic task re-planning

### DIFF
--- a/prisma/migrations/20260623000000_add_auto_replan_settings/migration.sql
+++ b/prisma/migrations/20260623000000_add_auto_replan_settings/migration.sql
@@ -1,0 +1,6 @@
+-- Periodic auto-replan settings on SystemSettings.
+-- A host heartbeat calls the internal cron endpoint; the endpoint re-plans only
+-- once the configured interval has elapsed, so cadence is admin-configurable.
+ALTER TABLE "SystemSettings" ADD COLUMN "autoReplanEnabled" BOOLEAN NOT NULL DEFAULT true;
+ALTER TABLE "SystemSettings" ADD COLUMN "autoReplanIntervalMinutes" INTEGER NOT NULL DEFAULT 15;
+ALTER TABLE "SystemSettings" ADD COLUMN "autoReplanLastRunAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -413,6 +413,12 @@ model SystemSettings {
   publicSignup        Boolean  @default(false) // Whether public signup is enabled
   disableHomepage     Boolean  @default(false) // Whether to disable the homepage and redirect to login/calendar
   resendApiKey        String? // API key for Resend email service
+  // Periodic auto-replan (driven by the internal cron endpoint). The host fires
+  // a frequent heartbeat; the endpoint only re-plans once this interval elapses,
+  // so the cadence is configurable in-app without touching the host schedule.
+  autoReplanEnabled         Boolean   @default(true)
+  autoReplanIntervalMinutes Int       @default(15) // conservative default; admins may go as low as 1 for near-continuous reflow
+  autoReplanLastRunAt       DateTime? // last time the heartbeat actually re-planned
   createdAt           DateTime @default(now())
   updatedAt           DateTime @updatedAt
 }

--- a/src/app/api/internal/cron/replan/__tests__/route.test.ts
+++ b/src/app/api/internal/cron/replan/__tests__/route.test.ts
@@ -1,0 +1,103 @@
+import { NextRequest } from "next/server";
+
+import { verifyCronSecret } from "@/lib/auth/cron-auth";
+import { prisma } from "@/lib/prisma";
+import { repushDirtyBlocks } from "@/lib/task-block-push";
+import { scheduleAllTasksForUser } from "@/services/scheduling/TaskSchedulingService";
+
+jest.mock("@/lib/auth/cron-auth");
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    autoScheduleSettings: { findMany: jest.fn() },
+    userSettings: { findUnique: jest.fn() },
+  },
+}));
+jest.mock("@/lib/logger");
+jest.mock("@/services/scheduling/TaskSchedulingService");
+jest.mock("@/lib/task-block-push");
+
+import { POST } from "../route";
+
+const mockVerify = verifyCronSecret as unknown as jest.Mock;
+const mockFindMany = prisma.autoScheduleSettings.findMany as unknown as jest.Mock;
+const mockUserSettings = prisma.userSettings.findUnique as unknown as jest.Mock;
+const mockSchedule = scheduleAllTasksForUser as unknown as jest.Mock;
+const mockRepush = repushDirtyBlocks as unknown as jest.Mock;
+
+const req = () => ({ headers: new Headers() }) as unknown as NextRequest;
+
+describe("POST /api/internal/cron/replan", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUserSettings.mockResolvedValue({ timeZone: "America/Chicago" });
+    mockSchedule.mockResolvedValue([]);
+    mockRepush.mockResolvedValue(undefined);
+  });
+
+  it("returns 404 when the endpoint is disabled (no CRON_SECRET)", async () => {
+    mockVerify.mockReturnValue("disabled");
+    const res = await POST(req());
+    expect(res.status).toBe(404);
+    expect(mockFindMany).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when the secret is wrong/missing", async () => {
+    mockVerify.mockReturnValue("unauthorized");
+    const res = await POST(req());
+    expect(res.status).toBe(401);
+    expect(mockFindMany).not.toHaveBeenCalled();
+  });
+
+  it("re-plans and re-syncs every ready user", async () => {
+    mockVerify.mockReturnValue("ok");
+    mockFindMany.mockResolvedValue([{ userId: "u1" }, { userId: "u2" }]);
+
+    const res = await POST(req());
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.replanned).toBe(2);
+    expect(body.skipped).toEqual([]);
+    expect(mockSchedule).toHaveBeenCalledWith("u1");
+    expect(mockSchedule).toHaveBeenCalledWith("u2");
+    // Each re-plan must be followed by a block re-sync so the calendar follows.
+    expect(mockRepush).toHaveBeenCalledWith("u1");
+    expect(mockRepush).toHaveBeenCalledWith("u2");
+  });
+
+  it("skips a user with no timezone without scheduling, and keeps going", async () => {
+    mockVerify.mockReturnValue("ok");
+    mockFindMany.mockResolvedValue([{ userId: "u1" }, { userId: "u2" }]);
+    mockUserSettings.mockImplementation(({ where }: { where: { userId: string } }) =>
+      where.userId === "u1"
+        ? Promise.resolve({ timeZone: null })
+        : Promise.resolve({ timeZone: "America/Chicago" })
+    );
+
+    const res = await POST(req());
+    const body = await res.json();
+
+    expect(body.replanned).toBe(1);
+    expect(body.skipped).toEqual([{ userId: "u1", reason: "no_timezone" }]);
+    expect(mockSchedule).not.toHaveBeenCalledWith("u1");
+    expect(mockSchedule).toHaveBeenCalledWith("u2");
+  });
+
+  it("isolates a failing user so the batch still completes", async () => {
+    mockVerify.mockReturnValue("ok");
+    mockFindMany.mockResolvedValue([{ userId: "u1" }, { userId: "u2" }]);
+    mockSchedule.mockImplementation((userId: string) =>
+      userId === "u1"
+        ? Promise.reject(new Error("boom"))
+        : Promise.resolve([])
+    );
+
+    const res = await POST(req());
+    const body = await res.json();
+
+    expect(body.replanned).toBe(1);
+    expect(body.skipped).toEqual([{ userId: "u1", reason: "replan_failed" }]);
+    expect(mockRepush).toHaveBeenCalledWith("u2");
+    expect(mockRepush).not.toHaveBeenCalledWith("u1");
+  });
+});

--- a/src/app/api/internal/cron/replan/__tests__/route.test.ts
+++ b/src/app/api/internal/cron/replan/__tests__/route.test.ts
@@ -8,6 +8,7 @@ import { scheduleAllTasksForUser } from "@/services/scheduling/TaskSchedulingSer
 jest.mock("@/lib/auth/cron-auth");
 jest.mock("@/lib/prisma", () => ({
   prisma: {
+    systemSettings: { findFirst: jest.fn(), update: jest.fn() },
     autoScheduleSettings: { findMany: jest.fn() },
     userSettings: { findUnique: jest.fn() },
   },
@@ -19,6 +20,8 @@ jest.mock("@/lib/task-block-push");
 import { POST } from "../route";
 
 const mockVerify = verifyCronSecret as unknown as jest.Mock;
+const mockSysFind = prisma.systemSettings.findFirst as unknown as jest.Mock;
+const mockSysUpdate = prisma.systemSettings.update as unknown as jest.Mock;
 const mockFindMany = prisma.autoScheduleSettings.findMany as unknown as jest.Mock;
 const mockUserSettings = prisma.userSettings.findUnique as unknown as jest.Mock;
 const mockSchedule = scheduleAllTasksForUser as unknown as jest.Mock;
@@ -29,6 +32,14 @@ const req = () => ({ headers: new Headers() }) as unknown as NextRequest;
 describe("POST /api/internal/cron/replan", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // Enabled, never run before -> due.
+    mockSysFind.mockResolvedValue({
+      id: "default",
+      autoReplanEnabled: true,
+      autoReplanIntervalMinutes: 15,
+      autoReplanLastRunAt: null,
+    });
+    mockSysUpdate.mockResolvedValue({});
     mockUserSettings.mockResolvedValue({ timeZone: "America/Chicago" });
     mockSchedule.mockResolvedValue([]);
     mockRepush.mockResolvedValue(undefined);
@@ -46,6 +57,53 @@ describe("POST /api/internal/cron/replan", () => {
     const res = await POST(req());
     expect(res.status).toBe(401);
     expect(mockFindMany).not.toHaveBeenCalled();
+  });
+
+  it("skips when auto-replan is disabled in settings", async () => {
+    mockVerify.mockReturnValue("ok");
+    mockSysFind.mockResolvedValue({
+      id: "default",
+      autoReplanEnabled: false,
+      autoReplanIntervalMinutes: 15,
+      autoReplanLastRunAt: null,
+    });
+
+    const body = await (await POST(req())).json();
+
+    expect(body.skipped).toBe("disabled");
+    expect(mockFindMany).not.toHaveBeenCalled();
+    expect(mockSysUpdate).not.toHaveBeenCalled();
+  });
+
+  it("throttles a heartbeat that fires before the interval elapses", async () => {
+    mockVerify.mockReturnValue("ok");
+    mockSysFind.mockResolvedValue({
+      id: "default",
+      autoReplanEnabled: true,
+      autoReplanIntervalMinutes: 15,
+      autoReplanLastRunAt: new Date(), // just ran -> not due
+    });
+
+    const body = await (await POST(req())).json();
+
+    expect(body.skipped).toBe("not_due");
+    expect(body.dueInSec).toBeGreaterThan(0);
+    expect(mockFindMany).not.toHaveBeenCalled();
+    expect(mockSysUpdate).not.toHaveBeenCalled();
+  });
+
+  it("claims the run by stamping lastRunAt before doing the work", async () => {
+    mockVerify.mockReturnValue("ok");
+    mockFindMany.mockResolvedValue([{ userId: "u1" }]);
+
+    await POST(req());
+
+    expect(mockSysUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "default" },
+        data: expect.objectContaining({ autoReplanLastRunAt: expect.any(Date) }),
+      })
+    );
   });
 
   it("re-plans and re-syncs every ready user", async () => {

--- a/src/app/api/internal/cron/replan/route.ts
+++ b/src/app/api/internal/cron/replan/route.ts
@@ -17,10 +17,13 @@ const LOG_SOURCE = "api-internal-cron-replan";
  * the past until the user next touches something. Hosted schedulers (Motion,
  * the SaaS edition) get this for free from a cloud worker; self-hosters don't.
  *
- * This endpoint is meant to be driven by a cron on the host (e.g. every 15 min
- * during work hours): it re-plans every auto-scheduling user and re-syncs the
- * pushed calendar blocks that moved, so past-due tasks roll forward on their own
- * and the user's calendar follows — even with no browser open.
+ * The host fires this on a frequent, fixed heartbeat (e.g. every minute); the
+ * cadence is governed in-app by SystemSettings.autoReplanIntervalMinutes, so an
+ * admin can dial the reflow from a conservative default (15 min) down to
+ * near-continuous (1 min) without ever touching the host schedule. When due it
+ * re-plans every auto-scheduling user and re-syncs the pushed calendar blocks
+ * that moved, so past-due tasks roll forward on their own and the calendar
+ * follows — even with no browser open.
  *
  * Auth is a shared secret (CRON_SECRET via Bearer), not a user API key. When
  * CRON_SECRET is unset the endpoint is disabled (404), so a default install
@@ -36,6 +39,36 @@ export async function POST(request: NextRequest) {
   if (auth === "unauthorized") {
     return new NextResponse("Unauthorized", { status: 401 });
   }
+
+  // Cadence is admin-controlled in SystemSettings; the host heartbeat may fire
+  // far more often than we want to re-plan. Gate on enabled + elapsed interval,
+  // and claim this run by stamping autoReplanLastRunAt BEFORE the work so two
+  // overlapping heartbeats can't both re-plan.
+  const settings = await prisma.systemSettings.findFirst({
+    select: {
+      id: true,
+      autoReplanEnabled: true,
+      autoReplanIntervalMinutes: true,
+      autoReplanLastRunAt: true,
+    },
+  });
+
+  if (!settings?.autoReplanEnabled) {
+    return NextResponse.json({ skipped: "disabled" });
+  }
+
+  const now = Date.now();
+  const intervalMs = Math.max(1, settings.autoReplanIntervalMinutes) * 60_000;
+  const lastRun = settings.autoReplanLastRunAt?.getTime() ?? 0;
+  if (now - lastRun < intervalMs) {
+    const dueInSec = Math.ceil((intervalMs - (now - lastRun)) / 1000);
+    return NextResponse.json({ skipped: "not_due", dueInSec });
+  }
+
+  await prisma.systemSettings.update({
+    where: { id: settings.id },
+    data: { autoReplanLastRunAt: new Date(now) },
+  });
 
   // Every user who has configured auto-scheduling. Single-tenant installs have
   // exactly one; iterating keeps this correct for multi-user self-hosting too.

--- a/src/app/api/internal/cron/replan/route.ts
+++ b/src/app/api/internal/cron/replan/route.ts
@@ -1,0 +1,86 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { verifyCronSecret } from "@/lib/auth/cron-auth";
+import { logger } from "@/lib/logger";
+import { prisma } from "@/lib/prisma";
+import { repushDirtyBlocks } from "@/lib/task-block-push";
+import { scheduleAllTasksForUser } from "@/services/scheduling/TaskSchedulingService";
+
+const LOG_SOURCE = "api-internal-cron-replan";
+
+/**
+ * POST /api/internal/cron/replan — server-side periodic re-plan.
+ *
+ * The self-hosted (OSS) build ships no background worker, so auto-scheduled
+ * tasks only move when a request triggers scheduleAllTasksForUser. Without a
+ * periodic nudge, an unfinished task whose slot has already passed just sits in
+ * the past until the user next touches something. Hosted schedulers (Motion,
+ * the SaaS edition) get this for free from a cloud worker; self-hosters don't.
+ *
+ * This endpoint is meant to be driven by a cron on the host (e.g. every 15 min
+ * during work hours): it re-plans every auto-scheduling user and re-syncs the
+ * pushed calendar blocks that moved, so past-due tasks roll forward on their own
+ * and the user's calendar follows — even with no browser open.
+ *
+ * Auth is a shared secret (CRON_SECRET via Bearer), not a user API key. When
+ * CRON_SECRET is unset the endpoint is disabled (404), so a default install
+ * never exposes an unauthenticated re-plan trigger.
+ */
+export async function POST(request: NextRequest) {
+  const auth = verifyCronSecret(request);
+  if (auth === "disabled") {
+    // Indistinguishable from a non-existent route: don't advertise the feature
+    // on installs that haven't opted in by setting CRON_SECRET.
+    return new NextResponse("Not Found", { status: 404 });
+  }
+  if (auth === "unauthorized") {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+
+  // Every user who has configured auto-scheduling. Single-tenant installs have
+  // exactly one; iterating keeps this correct for multi-user self-hosting too.
+  const users = await prisma.autoScheduleSettings.findMany({
+    select: { userId: true },
+  });
+
+  let replanned = 0;
+  const skipped: { userId: string; reason: string }[] = [];
+
+  for (const { userId } of users) {
+    try {
+      // The scheduler resolves the user's timezone from UserSettings.timeZone;
+      // if it was never set, it would silently fall back and place tasks in the
+      // wrong zone. Skip rather than mis-schedule on an unattended cron run.
+      const userSettings = await prisma.userSettings.findUnique({
+        where: { userId },
+        select: { timeZone: true },
+      });
+      if (!userSettings?.timeZone) {
+        skipped.push({ userId, reason: "no_timezone" });
+        continue;
+      }
+
+      await scheduleAllTasksForUser(userId);
+      // Re-sync the blocks the re-plan moved (scheduleAllTasksForUser flags them
+      // dirty); without this the calendar would keep showing the old times.
+      await repushDirtyBlocks(userId);
+      replanned += 1;
+    } catch (error) {
+      // One user's failure must not abort the batch.
+      logger.error(
+        "Cron re-plan failed for user",
+        { userId, error: error instanceof Error ? error.message : "unknown" },
+        LOG_SOURCE
+      );
+      skipped.push({ userId, reason: "replan_failed" });
+    }
+  }
+
+  logger.info(
+    "Cron re-plan complete",
+    { replanned, skipped: skipped.length },
+    LOG_SOURCE
+  );
+
+  return NextResponse.json({ replanned, skipped });
+}

--- a/src/components/settings/SystemSettings.tsx
+++ b/src/components/settings/SystemSettings.tsx
@@ -43,6 +43,8 @@ export function SystemSettings() {
           logLevel: data.logLevel,
           disableHomepage: data.disableHomepage,
           resendApiKey: data.resendApiKey,
+          autoReplanEnabled: data.autoReplanEnabled,
+          autoReplanIntervalMinutes: data.autoReplanIntervalMinutes,
         });
       })
       .catch((error) => {
@@ -265,6 +267,53 @@ export function SystemSettings() {
               When enabled, the homepage (/) will redirect to the login page for
               unauthenticated users or to the calendar for authenticated users.
             </p>
+          </div>
+        </SettingRow>
+
+        <SettingRow
+          label="Auto-Scheduling"
+          description="Periodically re-plan auto-scheduled tasks so unfinished, past-due tasks roll forward on their own — even with no browser open. Requires a host cron calling the internal re-plan endpoint."
+        >
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label>Periodic re-plan</Label>
+              <Select
+                value={system.autoReplanEnabled ? "true" : "false"}
+                onValueChange={(value) =>
+                  handleUpdate({ autoReplanEnabled: value === "true" })
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="true">Enabled</SelectItem>
+                  <SelectItem value="false">Disabled</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label>Re-plan every (minutes)</Label>
+              <Input
+                type="number"
+                min={1}
+                max={1440}
+                value={system.autoReplanIntervalMinutes ?? 15}
+                onChange={(e) => {
+                  const n = parseInt(e.target.value, 10);
+                  if (!Number.isNaN(n) && n >= 1) {
+                    handleUpdate({ autoReplanIntervalMinutes: n });
+                  }
+                }}
+              />
+              <p className="text-sm text-muted-foreground">
+                How often the schedule is recalculated. A conservative default of
+                15 is plenty for most people; lower it toward 1 for near
+                real-time reflow. The host cron is a fixed heartbeat — this is the
+                actual cadence, so changing it here needs no cron change.
+              </p>
+            </div>
           </div>
         </SettingRow>
 

--- a/src/lib/auth/__tests__/cron-auth.test.ts
+++ b/src/lib/auth/__tests__/cron-auth.test.ts
@@ -1,0 +1,52 @@
+import { NextRequest } from "next/server";
+
+import { verifyCronSecret } from "@/lib/auth/cron-auth";
+
+function reqWith(authHeader?: string): NextRequest {
+  const headers = new Headers();
+  if (authHeader !== undefined) headers.set("authorization", authHeader);
+  return { headers } as unknown as NextRequest;
+}
+
+describe("verifyCronSecret", () => {
+  const ORIGINAL = process.env.CRON_SECRET;
+  afterEach(() => {
+    if (ORIGINAL === undefined) delete process.env.CRON_SECRET;
+    else process.env.CRON_SECRET = ORIGINAL;
+  });
+
+  it("is disabled (fail closed) when CRON_SECRET is unset", () => {
+    delete process.env.CRON_SECRET;
+    expect(verifyCronSecret(reqWith("Bearer anything"))).toBe("disabled");
+  });
+
+  it("is unauthorized when no Authorization header is present", () => {
+    process.env.CRON_SECRET = "s3cret-value";
+    expect(verifyCronSecret(reqWith())).toBe("unauthorized");
+  });
+
+  it("is unauthorized when the scheme isn't Bearer", () => {
+    process.env.CRON_SECRET = "s3cret-value";
+    expect(verifyCronSecret(reqWith("Basic s3cret-value"))).toBe("unauthorized");
+  });
+
+  it("is unauthorized when the bearer token is empty", () => {
+    process.env.CRON_SECRET = "s3cret-value";
+    expect(verifyCronSecret(reqWith("Bearer "))).toBe("unauthorized");
+  });
+
+  it("is unauthorized when the secret doesn't match", () => {
+    process.env.CRON_SECRET = "s3cret-value";
+    expect(verifyCronSecret(reqWith("Bearer wrong-value"))).toBe("unauthorized");
+  });
+
+  it("is unauthorized for a value that merely shares a prefix", () => {
+    process.env.CRON_SECRET = "s3cret-value";
+    expect(verifyCronSecret(reqWith("Bearer s3cret-valu"))).toBe("unauthorized");
+  });
+
+  it("is ok when the bearer token matches CRON_SECRET", () => {
+    process.env.CRON_SECRET = "s3cret-value";
+    expect(verifyCronSecret(reqWith("Bearer s3cret-value"))).toBe("ok");
+  });
+});

--- a/src/lib/auth/cron-auth.ts
+++ b/src/lib/auth/cron-auth.ts
@@ -1,0 +1,40 @@
+import { createHash, timingSafeEqual } from "crypto";
+
+import { NextRequest } from "next/server";
+
+/**
+ * Shared-secret auth for internal cron endpoints (e.g. the periodic re-plan).
+ *
+ * This is deliberately NOT a user API key: a cron acts across every
+ * auto-scheduling user and must never be exposed as a user-facing credential.
+ * The secret lives in the app's own environment (CRON_SECRET), set by the
+ * operator, and is presented as `Authorization: Bearer <CRON_SECRET>`.
+ *
+ *   - "disabled"     CRON_SECRET is unset → the endpoint is OFF (fail closed),
+ *                    so it can never run unauthenticated on a default install.
+ *   - "unauthorized" CRON_SECRET is set but the request didn't present it.
+ *   - "ok"           the presented bearer matches.
+ *
+ * The compare is constant-time and the secret is never logged. We hash both
+ * sides to a fixed-length digest first so the timing-safe compare always runs
+ * on equal-length buffers and the request can't leak the secret's length.
+ */
+export type CronAuthResult = "ok" | "disabled" | "unauthorized";
+
+function digest(value: string): Buffer {
+  return createHash("sha256").update(value, "utf8").digest();
+}
+
+export function verifyCronSecret(request: NextRequest): CronAuthResult {
+  const expected = process.env.CRON_SECRET;
+  if (!expected) return "disabled";
+
+  const header = request.headers.get("authorization") ?? "";
+  if (!header.startsWith("Bearer ")) return "unauthorized";
+  const provided = header.slice(7).trim();
+  if (!provided) return "unauthorized";
+
+  return timingSafeEqual(digest(provided), digest(expected))
+    ? "ok"
+    : "unauthorized";
+}

--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -112,6 +112,8 @@ const defaultSettings: Settings & { accounts: ConnectedAccount[] } = {
     logRetention: undefined,
     logDestination: "db",
     disableHomepage: false,
+    autoReplanEnabled: true,
+    autoReplanIntervalMinutes: 15,
   },
   accounts: [],
 };
@@ -468,6 +470,8 @@ export const useSettingsStore = create<SettingsStore>()(
             logRetention: systemSettings.logRetention,
             logDestination: systemSettings.logDestination,
             disableHomepage: systemSettings.disableHomepage,
+            autoReplanEnabled: systemSettings.autoReplanEnabled,
+            autoReplanIntervalMinutes: systemSettings.autoReplanIntervalMinutes,
           });
         } catch (error) {
           logger.error(

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -95,6 +95,8 @@ export interface SystemSettings {
   disableHomepage?: boolean; // Whether to disable the homepage and redirect to login/calendar
   publicSignup?: boolean; // Whether public signup is enabled
   resendApiKey?: string; // API key for Resend email service
+  autoReplanEnabled?: boolean; // Periodically re-plan auto-scheduled tasks so past-due tasks roll forward
+  autoReplanIntervalMinutes?: number; // How often the re-plan runs (minutes); lower = closer to real-time
 }
 
 export interface Settings {


### PR DESCRIPTION
**Question for maintainers first:** periodic re-planning lives in the SaaS worker today, so OSS auto-scheduled tasks never roll forward unattended (finish-or-not, they sit on the day they were placed). This adds an OSS-side, auth-gated endpoint a host cron can poke to re-plan on a cadence.

**Is this an acceptable shape for OSS, or do you consider periodic re-planning SaaS-only?** Happy to adjust or close if this should stay in the SaaS worker.

What it does:
- `POST /api/internal/cron/replan`, guarded by `CRON_SECRET` (404 when unset = fail-closed, 401 on bad token, constant-time compare).
- Admin-configurable enable + cadence in System Settings; self-throttles to the configured interval.
- Re-plans and repushes calendar blocks per user.
- Adds 3 columns to `SystemSettings` (enabled, intervalMinutes, lastRunAt). 15 tests.

---
_Draft: baking on a live install 1–2 days; opening early for the architecture read._